### PR TITLE
Debug logging mode: opt-in logs + Apple Music artwork instrumentation

### DIFF
--- a/Jukebox.xcodeproj/project.pbxproj
+++ b/Jukebox.xcodeproj/project.pbxproj
@@ -496,7 +496,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1.2.1;
+				CURRENT_PROJECT_VERSION = 1.3.0;
 				DEVELOPMENT_ASSET_PATHS = "\"Jukebox/Preview Content\"";
 				DEVELOPMENT_TEAM = X72LEXP4DY;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -513,7 +513,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jaydenkerr.Jukebox;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -535,7 +535,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1.2.1;
+				CURRENT_PROJECT_VERSION = 1.3.0;
 				DEVELOPMENT_ASSET_PATHS = "\"Jukebox/Preview Content\"";
 				DEVELOPMENT_TEAM = X72LEXP4DY;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -552,7 +552,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jaydenkerr.Jukebox;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -592,8 +592,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sindresorhus/LaunchAtLogin-Modern";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.1.0;
 			};
 		};
 		D6A0B1012F2A000000000001 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/Jukebox.xcodeproj/project.pbxproj
+++ b/Jukebox.xcodeproj/project.pbxproj
@@ -11,6 +11,13 @@
 		D6F0E4A62F16F9E300123456 /* NowPlayingCompactView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6F0E4A52F16F9E300123456 /* NowPlayingCompactView.swift */; };
 		E800A8B22732811D00DBDF0E /* MenuMarqueeText.swift in Sources */ = {isa = PBXBuildFile; fileRef = E800A8B12732811D00DBDF0E /* MenuMarqueeText.swift */; };
 		E81CFEC227A12ED60030C448 /* Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81CFEC127A12ED60030C448 /* Helper.swift */; };
+		DB061000000000000000B101 /* LogLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB061000000000000000A101 /* LogLine.swift */; };
+		DB061000000000000000B102 /* LogFileWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB061000000000000000A102 /* LogFileWriter.swift */; };
+		DB061000000000000000B103 /* TrackSourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB061000000000000000A103 /* TrackSourceType.swift */; };
+		DB061000000000000000B104 /* DiagnosticsReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB061000000000000000A104 /* DiagnosticsReport.swift */; };
+		DB061000000000000000B105 /* FileLogSink.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB061000000000000000A105 /* FileLogSink.swift */; };
+		DB061000000000000000B106 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB061000000000000000A106 /* Log.swift */; };
+		DB061000000000000000B107 /* LogExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB061000000000000000A107 /* LogExporter.swift */; };
 		E82271BC2735514400D1795D /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = E82271BB2735514400D1795D /* Constants.swift */; };
 		E82271C3273567F000D1795D /* VisualizerStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = E82271C2273567F000D1795D /* VisualizerStyle.swift */; };
 		E8767C66273688FB00E39D17 /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = E8767C65273688FB00E39D17 /* LaunchAtLogin */; };
@@ -46,6 +53,13 @@
 		D6F0E4A52F16F9E300123456 /* NowPlayingCompactView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingCompactView.swift; sourceTree = "<group>"; };
 		E800A8B12732811D00DBDF0E /* MenuMarqueeText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuMarqueeText.swift; sourceTree = "<group>"; };
 		E81CFEC127A12ED60030C448 /* Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Helper.swift; sourceTree = "<group>"; };
+		DB061000000000000000A101 /* LogLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogLine.swift; sourceTree = "<group>"; };
+		DB061000000000000000A102 /* LogFileWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogFileWriter.swift; sourceTree = "<group>"; };
+		DB061000000000000000A103 /* TrackSourceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackSourceType.swift; sourceTree = "<group>"; };
+		DB061000000000000000A104 /* DiagnosticsReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsReport.swift; sourceTree = "<group>"; };
+		DB061000000000000000A105 /* FileLogSink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileLogSink.swift; sourceTree = "<group>"; };
+		DB061000000000000000A106 /* Log.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
+		DB061000000000000000A107 /* LogExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogExporter.swift; sourceTree = "<group>"; };
 		E82271BB2735514400D1795D /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		E82271C2273567F000D1795D /* VisualizerStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualizerStyle.swift; sourceTree = "<group>"; };
 		E87F08BD2782E0CC00742DA1 /* OnboardingWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingWindow.swift; sourceTree = "<group>"; };
@@ -203,6 +217,13 @@
 			children = (
 				E82271BB2735514400D1795D /* Constants.swift */,
 				E81CFEC127A12ED60030C448 /* Helper.swift */,
+				DB061000000000000000A101 /* LogLine.swift */,
+				DB061000000000000000A102 /* LogFileWriter.swift */,
+				DB061000000000000000A103 /* TrackSourceType.swift */,
+				DB061000000000000000A104 /* DiagnosticsReport.swift */,
+				DB061000000000000000A105 /* FileLogSink.swift */,
+				DB061000000000000000A106 /* Log.swift */,
+				DB061000000000000000A107 /* LogExporter.swift */,
 				E8AF5FC4272924AC00AACF65 /* String+Base64.swift */,
 				E88441BD272D3A4C00C7B650 /* String+Dimensions.swift */,
 				E8E00583272FFC8000D8AE1B /* NSAttributedString+Dimensions.swift */,
@@ -323,6 +344,13 @@
 				E82271BC2735514400D1795D /* Constants.swift in Sources */,
 				E8A3371A2797D5F70094A6D7 /* ConnectedApps.swift in Sources */,
 				E81CFEC227A12ED60030C448 /* Helper.swift in Sources */,
+				DB061000000000000000B101 /* LogLine.swift in Sources */,
+				DB061000000000000000B102 /* LogFileWriter.swift in Sources */,
+				DB061000000000000000B103 /* TrackSourceType.swift in Sources */,
+				DB061000000000000000B104 /* DiagnosticsReport.swift in Sources */,
+				DB061000000000000000B105 /* FileLogSink.swift in Sources */,
+				DB061000000000000000B106 /* Log.swift in Sources */,
+				DB061000000000000000B107 /* LogExporter.swift in Sources */,
 				E8D7CCCC273AA1BC006179D7 /* SpotifyApplication.swift in Sources */,
 				E8E00584272FFC8000D8AE1B /* NSAttributedString+Dimensions.swift in Sources */,
 				E88441BE272D3A4C00C7B650 /* String+Dimensions.swift in Sources */,

--- a/Jukebox.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Jukebox.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sindresorhus/LaunchAtLogin-Modern",
       "state" : {
-        "branch" : "main",
-        "revision" : "a04ec1c363be3627734f6dad757d82f5d4fa8fcc"
+        "revision" : "a04ec1c363be3627734f6dad757d82f5d4fa8fcc",
+        "version" : "1.1.0"
       }
     },
     {

--- a/Jukebox/JukeboxApp.swift
+++ b/Jukebox/JukeboxApp.swift
@@ -86,6 +86,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, NSWind
         // Initialize Popover Content
         popoverHostView = NSHostingView(rootView: ContentView(contentViewVM: contentViewVM))
         popoverHostView.frame = NSRect(x: 0, y: 0, width: popoverSize.width, height: popoverSize.height)
+        // Frame-driven sizing: on macOS 14+ NSHostingView reports its SwiftUI intrinsic size
+        // by default, which lets the popover grow past contentSize on macOS 26 (extra margin
+        // around the fixed-size album art). sizingOptions = [] makes it respect the 272x350
+        // frame, matching the tighter macOS 15 layout. (Same fix the floating window uses.)
+        popoverHostView.sizingOptions = []
 
         popover = NSPopover()
         popover.contentSize = popoverSize

--- a/Jukebox/JukeboxApp.swift
+++ b/Jukebox/JukeboxApp.swift
@@ -98,6 +98,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, NSWind
         popover.animates = true
         popover.contentViewController = NSViewController()
         popover.contentViewController?.view = popoverHostView
+        // Force the popover size. On macOS 26 `popover.contentSize` is honoured
+        // inconsistently (the popover grows past it); preferredContentSize is the canonical
+        // override that NSPopover respects.
+        popover.contentViewController?.preferredContentSize = popoverSize
 
         // Initialize Floating Window Content
         floatingHostView = SnapHostingView(rootView: NowPlayingCompactView(contentViewVM: contentViewVM))
@@ -195,6 +199,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, NSWind
                 popover.performClose(statusBarItemButton)
             } else {
                 popover.show(relativeTo: statusBarItemButton.bounds, of: statusBarItemButton, preferredEdge: .minY)
+                Log.general.debug("Popover shown: contentSize=\(popover.contentSize) "
+                    + "hostFrame=\(popoverHostView.frame.size) hostFitting=\(popoverHostView.fittingSize)")
                 NSApplication.shared.activate(ignoringOtherApps: true)
             }
         }

--- a/Jukebox/JukeboxApp.swift
+++ b/Jukebox/JukeboxApp.swift
@@ -191,6 +191,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, NSWind
             if nowPlayingWindow.isVisible {
                 nowPlayingWindow.orderOut(nil)
                 contentViewVM.pauseTimer()
+                contentViewVM.isResizing = false   // clear any latched live-resize state
             } else {
                 showNowPlayingWindow(relativeTo: statusBarItemButton)
             }
@@ -217,6 +218,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, NSWind
         } else {
             nowPlayingWindow.orderOut(nil)
             contentViewVM.pauseTimer()
+            contentViewVM.isResizing = false   // clear any latched live-resize state
         }
     }
 

--- a/Jukebox/JukeboxApp.swift
+++ b/Jukebox/JukeboxApp.swift
@@ -199,8 +199,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, NSWind
                 popover.performClose(statusBarItemButton)
             } else {
                 popover.show(relativeTo: statusBarItemButton.bounds, of: statusBarItemButton, preferredEdge: .minY)
-                Log.general.debug("Popover shown: contentSize=\(popover.contentSize) "
-                    + "hostFrame=\(popoverHostView.frame.size) hostFitting=\(popoverHostView.fittingSize)")
                 NSApplication.shared.activate(ignoringOtherApps: true)
             }
         }

--- a/Jukebox/JukeboxApp.swift
+++ b/Jukebox/JukeboxApp.swift
@@ -375,7 +375,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, NSWind
 
         if preferencesWindow == nil {
             preferencesWindow = PreferencesWindow()
-            let hostedPrefView = NSHostingView(rootView: PreferencesView(parentWindow: preferencesWindow))
+            let hostedPrefView = NSHostingView(rootView: PreferencesView(parentWindow: preferencesWindow, contentViewVM: contentViewVM))
             preferencesWindow.contentView = hostedPrefView
         }
 

--- a/Jukebox/ScriptingBridge/MusicApplication.swift
+++ b/Jukebox/ScriptingBridge/MusicApplication.swift
@@ -492,13 +492,13 @@ extension SBObject: MusicTrack {}
 
 // MARK: MusicAudioCDTrack
 @objc public protocol MusicAudioCDTrack: MusicTrack {
-    @objc optional var location: URL { get } // the location of the file represented by this track
+    @objc optional var location: URL? { get } // the location of the file (Optional: nil for streamed tracks; a non-optional URL traps when ScriptingBridge bridges the missing value)
 }
 extension SBObject: MusicAudioCDTrack {}
 
 // MARK: MusicFileTrack
 @objc public protocol MusicFileTrack: MusicTrack {
-    @objc optional var location: URL { get } // the location of the file represented by this track
+    @objc optional var location: URL? { get } // the location of the file (Optional: nil for streamed tracks; a non-optional URL traps when ScriptingBridge bridges the missing value)
     @objc optional func refresh() // update file track information from the current information in the track’s file
     @objc optional func setLocation(_ location: URL!) // the location of the file represented by this track
 }

--- a/Jukebox/Utilities/Constants.swift
+++ b/Jukebox/Utilities/Constants.swift
@@ -42,5 +42,12 @@ enum Constants {
         static let bundleID = "com.apple.Music"
         static let notification = "\(bundleID).playerInfo"
     }
-    
+
+    enum Logging {
+        static let subsystem = "com.jaydenkerr.Jukebox"
+        static let enabledKey = "debugLoggingEnabled"
+        static let logFileName = "Jukebox.log"
+        static let maxLogBytes = 5 * 1024 * 1024  // 5 MB; rolls once to Jukebox.log.1
+    }
+
 }

--- a/Jukebox/Utilities/DiagnosticsReport.swift
+++ b/Jukebox/Utilities/DiagnosticsReport.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/Jukebox/Utilities/DiagnosticsReport.swift
+++ b/Jukebox/Utilities/DiagnosticsReport.swift
@@ -1,1 +1,29 @@
 import Foundation
+
+/// Builds the human-readable header prepended to an exported log bundle.
+/// Values are injected so the builder is pure and verifiable in isolation.
+struct DiagnosticsReport {
+    let appVersion: String
+    let osVersion: String
+    let connectedApp: String
+    let isRunning: Bool
+    let permissionStatus: String
+    let debugLoggingEnabled: Bool
+    let currentTrackSource: String
+    let exportedAt: Date
+
+    func header() -> String {
+        return """
+        Jukebox Diagnostics
+        ===================
+        Exported:       \(LogLine.timestamp(exportedAt))
+        App version:    \(appVersion)
+        macOS:          \(osVersion)
+        Connected app:  \(connectedApp)
+        App running:    \(isRunning ? "yes" : "no")
+        Automation:     \(permissionStatus)
+        Debug logging:  \(debugLoggingEnabled ? "enabled" : "disabled")
+        Current track:  \(currentTrackSource)
+        """
+    }
+}

--- a/Jukebox/Utilities/FileLogSink.swift
+++ b/Jukebox/Utilities/FileLogSink.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/Jukebox/Utilities/FileLogSink.swift
+++ b/Jukebox/Utilities/FileLogSink.swift
@@ -17,7 +17,9 @@ final class FileLogSink {
         writer = url.map { LogFileWriter(fileURL: $0, maxBytes: Constants.Logging.maxLogBytes) }
     }
 
-    private var isEnabled: Bool {
+    /// Reflects the opt-in `debugLoggingEnabled` preference. Exposed so the Log
+    /// facade can skip building and emitting messages entirely when logging is off.
+    var isEnabled: Bool {
         UserDefaults.standard.bool(forKey: Constants.Logging.enabledKey)
     }
 

--- a/Jukebox/Utilities/FileLogSink.swift
+++ b/Jukebox/Utilities/FileLogSink.swift
@@ -1,1 +1,39 @@
 import Foundation
+
+/// Singleton file sink. Resolves the Application Support log path, gates
+/// writes on the opt-in `debugLoggingEnabled` preference, and serialises
+/// appends on a dedicated queue. Delegates rotation to LogFileWriter.
+final class FileLogSink {
+    static let shared = FileLogSink()
+
+    /// nil if Application Support could not be resolved.
+    let logFileURL: URL?
+    private let writer: LogFileWriter?
+    private let queue = DispatchQueue(label: "\(Constants.Logging.subsystem).filelog", qos: .utility)
+
+    private init() {
+        let url = FileLogSink.defaultLogFileURL()
+        logFileURL = url
+        writer = url.map { LogFileWriter(fileURL: $0, maxBytes: Constants.Logging.maxLogBytes) }
+    }
+
+    private var isEnabled: Bool {
+        UserDefaults.standard.bool(forKey: Constants.Logging.enabledKey)
+    }
+
+    func write(category: String, level: String, message: String) {
+        guard isEnabled, let writer else { return }
+        let line = LogLine.format(date: Date(), category: category, level: level, message: message)
+        queue.async { writer.append(line) }
+    }
+
+    private static func defaultLogFileURL() -> URL? {
+        guard let support = try? FileManager.default.url(
+            for: .applicationSupportDirectory, in: .userDomainMask,
+            appropriateFor: nil, create: true) else { return nil }
+        return support
+            .appendingPathComponent("Jukebox", isDirectory: true)
+            .appendingPathComponent("Logs", isDirectory: true)
+            .appendingPathComponent(Constants.Logging.logFileName)
+    }
+}

--- a/Jukebox/Utilities/Helper.swift
+++ b/Jukebox/Utilities/Helper.swift
@@ -19,16 +19,16 @@ class Helper {
         
         switch status {
         case -600:
-            print("The application with BundleID: \(appBundleID) is not open.")
+            Log.permissions.notice("Automation target not open: \(appBundleID)")
             return .closed
         case -0:
-            print("Permissions granted for the application with BundleID: \(appBundleID).")
+            Log.permissions.info("Automation permission granted: \(appBundleID)")
             return .granted
         case -1744:
-            print("User consent required but not prompted for the application with BundleID: \(appBundleID).")
+            Log.permissions.notice("Automation consent required but not prompted: \(appBundleID)")
             return .notPrompted
         default:
-            print("The user has declined permission for the application with BundleID: \(appBundleID).")
+            Log.permissions.notice("Automation permission denied: \(appBundleID)")
             return .denied
         }
     }

--- a/Jukebox/Utilities/Log.swift
+++ b/Jukebox/Utilities/Log.swift
@@ -1,2 +1,40 @@
 import Foundation
 import os
+
+/// App-wide logging facade. Every call goes to os.Logger (always) and to
+/// FileLogSink (only when debug logging is enabled).
+enum Log {
+    static let general = LogCategory("general")
+    static let playback = LogCategory("playback")
+    static let artwork = LogCategory("artwork")
+    static let permissions = LogCategory("permissions")
+}
+
+struct LogCategory {
+    enum Level: String { case debug = "DEBUG", info = "INFO", notice = "NOTICE", error = "ERROR" }
+
+    let name: String
+    private let logger: Logger
+
+    init(_ name: String) {
+        self.name = name
+        self.logger = Logger(subsystem: Constants.Logging.subsystem, category: name)
+    }
+
+    func debug(_ message: String)  { emit(.debug, message) }
+    func info(_ message: String)   { emit(.info, message) }
+    func notice(_ message: String) { emit(.notice, message) }
+    func error(_ message: String)  { emit(.error, message) }
+
+    private func emit(_ level: Level, _ message: String) {
+        // .public so values are readable in Console.app and exported logs —
+        // this is opt-in diagnostic logging the user chooses to share.
+        switch level {
+        case .debug:  logger.debug("\(message, privacy: .public)")
+        case .info:   logger.info("\(message, privacy: .public)")
+        case .notice: logger.notice("\(message, privacy: .public)")
+        case .error:  logger.error("\(message, privacy: .public)")
+        }
+        FileLogSink.shared.write(category: name, level: level.rawValue, message: message)
+    }
+}

--- a/Jukebox/Utilities/Log.swift
+++ b/Jukebox/Utilities/Log.swift
@@ -1,8 +1,12 @@
 import Foundation
 import os
 
-/// App-wide logging facade. Every call goes to os.Logger (always) and to
-/// FileLogSink (only when debug logging is enabled).
+/// App-wide logging facade. Logging is gated on the opt-in `debugLoggingEnabled`
+/// preference: when it is off, the message autoclosure is never evaluated — so
+/// building diagnostic strings (some of which make ScriptingBridge round-trips)
+/// costs nothing — and nothing is written to os.Logger or the file. When it is on,
+/// each line goes to os.Logger (.public, so it is readable in Console.app and in
+/// exported logs the user chooses to share) and to FileLogSink.
 enum Log {
     static let general = LogCategory("general")
     static let playback = LogCategory("playback")
@@ -21,20 +25,22 @@ struct LogCategory {
         self.logger = Logger(subsystem: Constants.Logging.subsystem, category: name)
     }
 
-    func debug(_ message: String)  { emit(.debug, message) }
-    func info(_ message: String)   { emit(.info, message) }
-    func notice(_ message: String) { emit(.notice, message) }
-    func error(_ message: String)  { emit(.error, message) }
+    func debug(_ message: @autoclosure () -> String)  { emit(.debug, message) }
+    func info(_ message: @autoclosure () -> String)   { emit(.info, message) }
+    func notice(_ message: @autoclosure () -> String) { emit(.notice, message) }
+    func error(_ message: @autoclosure () -> String)  { emit(.error, message) }
 
-    private func emit(_ level: Level, _ message: String) {
-        // .public so values are readable in Console.app and exported logs —
-        // this is opt-in diagnostic logging the user chooses to share.
+    private func emit(_ level: Level, _ message: () -> String) {
+        // Opt-in only. Bail before evaluating the message so callers never pay for
+        // building log strings (or the reads behind them) while logging is disabled.
+        guard FileLogSink.shared.isEnabled else { return }
+        let text = message()
         switch level {
-        case .debug:  logger.debug("\(message, privacy: .public)")
-        case .info:   logger.info("\(message, privacy: .public)")
-        case .notice: logger.notice("\(message, privacy: .public)")
-        case .error:  logger.error("\(message, privacy: .public)")
+        case .debug:  logger.debug("\(text, privacy: .public)")
+        case .info:   logger.info("\(text, privacy: .public)")
+        case .notice: logger.notice("\(text, privacy: .public)")
+        case .error:  logger.error("\(text, privacy: .public)")
         }
-        FileLogSink.shared.write(category: name, level: level.rawValue, message: message)
+        FileLogSink.shared.write(category: name, level: level.rawValue, message: text)
     }
 }

--- a/Jukebox/Utilities/Log.swift
+++ b/Jukebox/Utilities/Log.swift
@@ -1,0 +1,2 @@
+import Foundation
+import os

--- a/Jukebox/Utilities/LogExporter.swift
+++ b/Jukebox/Utilities/LogExporter.swift
@@ -1,0 +1,1 @@
+import AppKit

--- a/Jukebox/Utilities/LogExporter.swift
+++ b/Jukebox/Utilities/LogExporter.swift
@@ -1,1 +1,36 @@
 import AppKit
+
+/// Combines the diagnostics header with the log file into a single .txt and
+/// reveals it in Finder for the user to send.
+enum LogExporter {
+    enum Outcome {
+        case revealed(URL)
+        case noLogs
+        case failed(Error)
+    }
+
+    static func export(report: DiagnosticsReport) -> Outcome {
+        guard let logURL = FileLogSink.shared.logFileURL,
+              let logText = try? String(contentsOf: logURL, encoding: .utf8),
+              !logText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return .noLogs
+        }
+        let combined = report.header() + "\n\n===== LOG =====\n\n" + logText
+        let exportURL = logURL.deletingLastPathComponent()
+            .appendingPathComponent("Jukebox-Diagnostics-\(fileTimestamp(report.exportedAt)).txt")
+        do {
+            try combined.write(to: exportURL, atomically: true, encoding: .utf8)
+            NSWorkspace.shared.activateFileViewerSelecting([exportURL])
+            return .revealed(exportURL)
+        } catch {
+            return .failed(error)
+        }
+    }
+
+    private static func fileTimestamp(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        return formatter.string(from: date)
+    }
+}

--- a/Jukebox/Utilities/LogFileWriter.swift
+++ b/Jukebox/Utilities/LogFileWriter.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/Jukebox/Utilities/LogFileWriter.swift
+++ b/Jukebox/Utilities/LogFileWriter.swift
@@ -1,1 +1,58 @@
 import Foundation
+
+/// AppKit-free, size-capped append-only log writer with a single rollover.
+/// The path is injected so this type is verifiable in isolation. Not
+/// thread-safe alone; callers serialise access (FileLogSink uses a queue).
+final class LogFileWriter {
+    private let fileURL: URL
+    private let rolledURL: URL
+    private let maxBytes: Int
+    private let fileManager: FileManager
+
+    init(fileURL: URL, maxBytes: Int, fileManager: FileManager = .default) {
+        self.fileURL = fileURL
+        self.rolledURL = fileURL.appendingPathExtension("1") // e.g. Jukebox.log.1
+        self.maxBytes = maxBytes
+        self.fileManager = fileManager
+    }
+
+    /// Appends one line (a trailing newline is added), rotating first if needed.
+    func append(_ line: String) {
+        let data = Data((line + "\n").utf8)
+        ensureFileExists()
+        rotateIfNeeded(incomingBytes: data.count)
+        guard let handle = try? FileHandle(forWritingTo: fileURL) else { return }
+        defer { try? handle.close() }
+        _ = try? handle.seekToEnd()
+        try? handle.write(contentsOf: data)
+    }
+
+    /// Pure rotation decision — extracted so it can be verified directly.
+    static func shouldRotate(currentBytes: Int, incomingBytes: Int, maxBytes: Int) -> Bool {
+        return currentBytes > 0 && currentBytes + incomingBytes > maxBytes
+    }
+
+    private func rotateIfNeeded(incomingBytes: Int) {
+        guard LogFileWriter.shouldRotate(currentBytes: currentBytes(),
+                                         incomingBytes: incomingBytes,
+                                         maxBytes: maxBytes) else { return }
+        try? fileManager.removeItem(at: rolledURL)
+        try? fileManager.moveItem(at: fileURL, to: rolledURL)
+        fileManager.createFile(atPath: fileURL.path, contents: nil)
+    }
+
+    private func ensureFileExists() {
+        let dir = fileURL.deletingLastPathComponent()
+        if !fileManager.fileExists(atPath: dir.path) {
+            try? fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+        if !fileManager.fileExists(atPath: fileURL.path) {
+            fileManager.createFile(atPath: fileURL.path, contents: nil)
+        }
+    }
+
+    private func currentBytes() -> Int {
+        let attrs = try? fileManager.attributesOfItem(atPath: fileURL.path)
+        return (attrs?[.size] as? Int) ?? 0
+    }
+}

--- a/Jukebox/Utilities/LogLine.swift
+++ b/Jukebox/Utilities/LogLine.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/Jukebox/Utilities/LogLine.swift
+++ b/Jukebox/Utilities/LogLine.swift
@@ -1,1 +1,18 @@
 import Foundation
+
+/// Pure, AppKit-free formatting of a single log line. Dependency-free so it
+/// can be verified by scripts/verify-logging.swift.
+enum LogLine {
+    /// `2026-06-15T05:18:00.123Z  [category]  LEVEL  message`
+    static func format(date: Date, category: String, level: String, message: String) -> String {
+        return "\(timestamp(date))  [\(category)]  \(level)  \(message)"
+    }
+
+    /// ISO-8601 in UTC, millisecond precision, trailing `Z`.
+    static func timestamp(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        return formatter.string(from: date)
+    }
+}

--- a/Jukebox/Utilities/TrackSourceType.swift
+++ b/Jukebox/Utilities/TrackSourceType.swift
@@ -1,0 +1,1 @@
+import Foundation

--- a/Jukebox/Utilities/TrackSourceType.swift
+++ b/Jukebox/Utilities/TrackSourceType.swift
@@ -1,1 +1,38 @@
 import Foundation
+
+/// Whether the currently-playing track is a local file or streamed.
+enum TrackSourceType: String {
+    case localFile
+    case streamed
+    case internetRadioStream
+    case unknown
+}
+
+/// Raw signals captured from a Music track plus the derived source type.
+/// The classifier is pure (primitive inputs) so it is verifiable in isolation.
+struct TrackDiagnostics: CustomStringConvertible {
+    let sourceType: TrackSourceType
+    let cloudStatus: String
+    let kind: String
+    let mediaKind: String
+    let hasLocation: Bool
+    let sizeBytes: Int64
+    let address: String?
+
+    /// Cloud statuses that indicate an Apple Music cloud/catalogue track.
+    private static let cloudStatuses: Set<String> = ["subscription", "purchased", "matched", "uploaded"]
+
+    static func classify(hasAddress: Bool, hasFileLocation: Bool, cloudStatus: String) -> TrackSourceType {
+        if hasAddress { return .internetRadioStream }
+        if hasFileLocation { return .localFile }
+        if cloudStatuses.contains(cloudStatus) { return .streamed }
+        return .unknown
+    }
+
+    /// Single-line, log-friendly summary.
+    var description: String {
+        let addr = address.map { ", address=\($0)" } ?? ""
+        return "source=\(sourceType.rawValue) cloudStatus=\(cloudStatus) kind=\"\(kind)\" "
+            + "mediaKind=\(mediaKind) hasLocation=\(hasLocation) size=\(sizeBytes)\(addr)"
+    }
+}

--- a/Jukebox/Utilities/TrackSourceType.swift
+++ b/Jukebox/Utilities/TrackSourceType.swift
@@ -22,10 +22,16 @@ struct TrackDiagnostics: CustomStringConvertible {
     /// Cloud statuses that indicate an Apple Music cloud/catalogue track.
     private static let cloudStatuses: Set<String> = ["subscription", "purchased", "matched", "uploaded"]
 
-    static func classify(hasAddress: Bool, hasFileLocation: Bool, cloudStatus: String) -> TrackSourceType {
+    /// Size is the local-file discriminator: a genuine local file has a file:// location
+    /// AND a non-zero byte size. On macOS 26.5 streamed Apple Music tracks also report a
+    /// location, so location alone is not sufficient — a zero size (no local bytes) means
+    /// the track is streamed/cloud, not local. A known iCloud/Apple-Music cloud status wins
+    /// outright.
+    static func classify(hasAddress: Bool, hasFileLocation: Bool, cloudStatus: String, sizeBytes: Int64) -> TrackSourceType {
         if hasAddress { return .internetRadioStream }
-        if hasFileLocation { return .localFile }
         if cloudStatuses.contains(cloudStatus) { return .streamed }
+        if hasFileLocation && sizeBytes > 0 { return .localFile }
+        if sizeBytes == 0 { return .streamed }
         return .unknown
     }
 

--- a/Jukebox/ViewModels/ContentViewModel.swift
+++ b/Jukebox/ViewModels/ContentViewModel.swift
@@ -296,6 +296,37 @@ class ContentViewModel: ObservableObject {
         }
     }
 
+    /// Snapshot of current app/track state for the exported diagnostics header.
+    func currentDiagnostics() -> DiagnosticsReport {
+        let bundleID = connectedApp == .spotify ? Constants.Spotify.bundleID : Constants.AppleMusic.bundleID
+        let permission = Helper.promptUserForConsent(for: bundleID)
+        let trackSource: String
+        switch connectedApp {
+        case .appleMusic:
+            trackSource = makeAppleMusicTrackDiagnostics()?.description ?? "no track"
+        case .spotify:
+            trackSource = "source=streamed (Spotify)"
+        }
+        return DiagnosticsReport(
+            appVersion: Constants.AppInfo.appVersion ?? "?",
+            osVersion: ProcessInfo.processInfo.operatingSystemVersionString,
+            connectedApp: name,
+            isRunning: isRunning,
+            permissionStatus: Self.permissionName(permission),
+            debugLoggingEnabled: UserDefaults.standard.bool(forKey: Constants.Logging.enabledKey),
+            currentTrackSource: trackSource,
+            exportedAt: Date())
+    }
+
+    private static func permissionName(_ status: Helper.PermissionStatus) -> String {
+        switch status {
+        case .closed: return "app not open"
+        case .granted: return "granted"
+        case .notPrompted: return "not prompted"
+        case .denied: return "denied"
+        }
+    }
+
     private func updateMenuBarText(isStopped: Bool = false) {
         DispatchQueue.main.async { [weak self] in
             guard let self, let title = self.track.title as String?,

--- a/Jukebox/ViewModels/ContentViewModel.swift
+++ b/Jukebox/ViewModels/ContentViewModel.swift
@@ -198,30 +198,39 @@ class ContentViewModel: ObservableObject {
                 var count = 0
                 var waitForData: (() -> Void)!
                 waitForData = {
-                    let art = self.appleMusicApp?.currentTrack?.artworks?()[0] as! MusicArtwork
-                    let dataImage = art.data
-                    let dataIsEmpty = dataImage?.isEmpty() ?? true
-                    if dataImage != nil && !dataIsEmpty {
-                        Log.artwork.info("Artwork resolved from `data` on attempt \(count) "
-                            + "(size \(Int(dataImage!.size.width))x\(Int(dataImage!.size.height)))")
-                        self.track.albumArt = dataImage!
+                    guard let art = self.appleMusicApp?.currentTrack?.artworks?().first as? MusicArtwork else {
+                        self.track.albumArt = NSImage()
+                        return
+                    }
+                    // Build the image from `rawData` (the artwork bytes in their original
+                    // format). The legacy `data` ("picture") property returns a raw
+                    // NSAppleEventDescriptor on macOS 26.5 — NOT an NSImage — so calling any
+                    // NSImage method on it crashes (unrecognized selector) and it never
+                    // yields artwork. `rawData` is the supported path.
+                    let rawBytes: Data?
+                    switch art.rawData {
+                    case let bytes as Data:   rawBytes = bytes
+                    case let bytes as NSData: rawBytes = bytes as Data
+                    default:                  rawBytes = nil
+                    }
+                    if let bytes = rawBytes, !bytes.isEmpty, let image = NSImage(data: bytes) {
+                        Log.artwork.info("Artwork resolved from `rawData` on attempt \(count) "
+                            + "(\(bytes.count) bytes, \(Int(image.size.width))x\(Int(image.size.height)))")
+                        self.track.albumArt = image
                     } else {
-                        // Diagnose why `data` is unusable and whether `rawData` has bytes.
-                        let rawDesc: String
-                        switch art.rawData {
-                        case let bytes as Data:   rawDesc = "Data(\(bytes.count) bytes)"
-                        case let bytes as NSData: rawDesc = "NSData(\(bytes.length) bytes)"
-                        case let other?:          rawDesc = "\(type(of: other))"
-                        default:                  rawDesc = "nil"
-                        }
+                        // Not ready yet (or unavailable). Log the signals, including the
+                        // runtime class of `data`/`rawData` via a SAFE type check — never
+                        // call NSImage methods on `data` (it may be an NSAppleEventDescriptor).
+                        let dataClass = (art.data as AnyObject?).map { "\(type(of: $0))" } ?? "nil"
+                        let rawClass = (art.rawData as AnyObject?).map { "\(type(of: $0))" } ?? "nil"
                         Log.artwork.debug("attempt \(count): "
-                            + "data=\(dataImage == nil ? "nil" : "empty=\(dataIsEmpty)") "
+                            + "rawData=\(rawBytes.map { "\($0.count) bytes" } ?? "no usable bytes (class \(rawClass))") "
+                            + "data-class=\(dataClass) "
                             + "format=\(art.format.map { "\($0)" } ?? "nil") "
-                            + "downloaded=\(art.downloaded.map { "\($0)" } ?? "nil") "
-                            + "rawData=\(rawDesc)")
+                            + "downloaded=\(art.downloaded.map { "\($0)" } ?? "nil")")
                         if count > 20 {
                             Log.artwork.error("Artwork timed out after \(count) attempts; "
-                                + "`data` never produced a usable image. rawData=\(rawDesc)")
+                                + "`rawData` never produced a usable image")
                             self.track.albumArt = NSImage()
                             return
                         }

--- a/Jukebox/ViewModels/ContentViewModel.swift
+++ b/Jukebox/ViewModels/ContentViewModel.swift
@@ -191,10 +191,11 @@ class ContentViewModel: ObservableObject {
             let artworkCount = self.appleMusicApp?.currentTrack?.artworks?().count ?? 0
             Log.artwork.debug("artworks().count = \(artworkCount)")
 
-            if artworkCount == 0 {
-                Log.artwork.notice("No artwork present for current track; clearing album art")
-                self.track.albumArt = NSImage()
-            } else {
+            // Always poll: Apple Music loads streamed artwork asynchronously, so artworks()
+            // is frequently empty (count 0) at the moment of a track change and populates a
+            // second or two later. Re-check each attempt rather than bailing on the first
+            // empty read; clear stale art immediately, and time out if it never arrives.
+            do {
                 var count = 0
                 var waitForData: (() -> Void)!
                 waitForData = {
@@ -203,9 +204,19 @@ class ContentViewModel: ObservableObject {
                     // yields nil for it even when count > 0. Never return silently.
                     let artworks = self.appleMusicApp?.currentTrack?.artworks?()
                     guard let artworks, artworks.count > 0, let art = artworks[0] as? MusicArtwork else {
-                        Log.artwork.debug("attempt \(count): no usable artwork object on re-read "
-                            + "(count=\(artworks?.count ?? 0)); clearing album art")
-                        self.track.albumArt = NSImage()
+                        // No artwork yet — Apple Music may still be loading it. Clear any stale
+                        // art on the first miss, then keep polling until it appears or we time out.
+                        if count == 0 { self.track.albumArt = NSImage() }
+                        if count > 20 {
+                            Log.artwork.notice("No artwork after \(count) attempts "
+                                + "(count=\(artworks?.count ?? 0)); cleared album art")
+                            self.track.albumArt = NSImage()
+                            return
+                        }
+                        Log.artwork.debug("attempt \(count): artworks empty "
+                            + "(count=\(artworks?.count ?? 0)); waiting for async load")
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { waitForData() }
+                        count += 1
                         return
                     }
                     // Resolve artwork across OS versions. On macOS <= 15 `data` is a genuine

--- a/Jukebox/ViewModels/ContentViewModel.swift
+++ b/Jukebox/ViewModels/ContentViewModel.swift
@@ -64,7 +64,7 @@ class ContentViewModel: ObservableObject {
     // MARK: - Setup
     
     private func setupMusicApps() {
-        print("Setting up music apps")
+        Log.general.info("Setting up music apps for \(name)")
         switch connectedApp {
         case .spotify:
             guard spotifyApp == nil else { return }
@@ -128,7 +128,7 @@ class ContentViewModel: ObservableObject {
             return
         }
 
-        print("The play state or the currently playing track changed")
+        Log.playback.debug("Play state or current track changed")
         getPlayState()
         getTrackInformation()
         startMenuBarProgressUpdates()
@@ -144,7 +144,7 @@ class ContentViewModel: ObservableObject {
     
     func getTrackInformation() {
         
-        print("Getting track information...")
+        Log.playback.debug("Getting track information for \(name)")
         
         switch connectedApp {
         case .spotify:
@@ -281,7 +281,7 @@ class ContentViewModel: ObservableObject {
                 self.isLoved = !isLovedTrack
             }
         case .spotify:
-            print("Not supported")
+            Log.playback.notice("Love is not supported for Spotify")
         }
     }
     

--- a/Jukebox/ViewModels/ContentViewModel.swift
+++ b/Jukebox/ViewModels/ContentViewModel.swift
@@ -198,7 +198,13 @@ class ContentViewModel: ObservableObject {
                 var count = 0
                 var waitForData: (() -> Void)!
                 waitForData = {
-                    guard let art = self.appleMusicApp?.currentTrack?.artworks?().first as? MusicArtwork else {
+                    // SBElementArray is a lazy ScriptingBridge collection: use its [index]
+                    // subscript (a faulting proxy element), NOT Swift's `.first`, which
+                    // yields nil for it even when count > 0. Never return silently.
+                    let artworks = self.appleMusicApp?.currentTrack?.artworks?()
+                    guard let artworks, artworks.count > 0, let art = artworks[0] as? MusicArtwork else {
+                        Log.artwork.debug("attempt \(count): no usable artwork object on re-read "
+                            + "(count=\(artworks?.count ?? 0)); clearing album art")
                         self.track.albumArt = NSImage()
                         return
                     }

--- a/Jukebox/ViewModels/ContentViewModel.swift
+++ b/Jukebox/ViewModels/ContentViewModel.swift
@@ -208,12 +208,12 @@ class ContentViewModel: ObservableObject {
                         self.track.albumArt = NSImage()
                         return
                     }
-                    // macOS 26.5: Music's ScriptingBridge artwork accessors don't return
-                    // decoded bytes — `rawData` comes back as an opaque SBObject proxy and
-                    // `data` as a raw NSAppleEventDescriptor. Recover bytes by trying, in order:
-                    // rawData as Data; resolving the rawData proxy via SBObject.get(); the data
-                    // descriptor's payload. Never call NSImage methods on `data` directly
-                    // (it can be an NSAppleEventDescriptor — that crashes 'unrecognized selector').
+                    // Resolve artwork across OS versions. On macOS <= 15 `data` is a genuine
+                    // NSImage — use it directly. On macOS 26.5 `data` is an NSAppleEventDescriptor
+                    // and `rawData` an opaque SBObject proxy, so fall back to recovering bytes via
+                    // SBObject.get() / the descriptor payload. `as? NSImage` is safe on 26.5 (a
+                    // descriptor isn't an NSImage -> nil), so we never call NSImage methods on a
+                    // descriptor.
                     func imageBytes(_ value: Any?) -> Data? {
                         switch value {
                         case let d as Data where !d.isEmpty:     return d
@@ -221,25 +221,37 @@ class ContentViewModel: ObservableObject {
                         default:                                 return nil
                         }
                     }
-                    let rawValue = art.rawData
                     let dataValue = art.data
+                    let rawValue = art.rawData
+                    let dataImage = (dataValue as AnyObject?).flatMap { $0 as? NSImage }
                     let rawDirect = imageBytes(rawValue)
                     let rawResolved = imageBytes(rawValue.flatMap { $0 as? SBObject }?.get())
-                    let descBytes = dataValue
-                        .flatMap { ($0 as AnyObject) as? NSAppleEventDescriptor }?.data
+                    let descBytes = (dataValue as AnyObject?).flatMap { $0 as? NSAppleEventDescriptor }?.data
                     let descResolved = (descBytes?.isEmpty == false) ? descBytes : nil
-                    let candidates: [(String, Data)] = [
-                        ("rawData", rawDirect),
-                        ("rawData.get()", rawResolved),
-                        ("data-descriptor", descResolved),
-                    ].compactMap { pair in pair.1.map { (pair.0, $0) } }
-                    if let hit = candidates.first(where: { NSImage(data: $0.1) != nil }),
-                       let image = NSImage(data: hit.1) {
-                        Log.artwork.info("Artwork resolved via \(hit.0) on attempt \(count) "
-                            + "(\(hit.1.count) bytes, \(Int(image.size.width))x\(Int(image.size.height)))")
-                        self.track.albumArt = image
+
+                    let resolved: (source: String, image: NSImage)? = {
+                        if let dataImage, !dataImage.isEmpty() {
+                            return ("data(NSImage)", dataImage)   // macOS <= 15
+                        }
+                        let byteRoutes: [(String, Data)] = [
+                            ("rawData", rawDirect),
+                            ("rawData.get()", rawResolved),
+                            ("data-descriptor", descResolved),
+                        ].compactMap { pair in pair.1.map { (pair.0, $0) } }
+                        if let hit = byteRoutes.first(where: { NSImage(data: $0.1) != nil }),
+                           let image = NSImage(data: hit.1) {
+                            return ("\(hit.0)(\(hit.1.count)b)", image)   // macOS 26.5
+                        }
+                        return nil
+                    }()
+
+                    if let resolved {
+                        Log.artwork.info("Artwork resolved via \(resolved.source) on attempt \(count) "
+                            + "(\(Int(resolved.image.size.width))x\(Int(resolved.image.size.height)))")
+                        self.track.albumArt = resolved.image
                     } else {
                         Log.artwork.debug("attempt \(count): "
+                            + "data(NSImage)=\(dataImage != nil) "
                             + "rawData=\(rawDirect?.count.description ?? "nil") "
                             + "rawData.get()=\(rawResolved?.count.description ?? "nil") "
                             + "data-descriptor=\(descResolved?.count.description ?? "nil") "
@@ -249,7 +261,7 @@ class ContentViewModel: ObservableObject {
                             + "downloaded=\(art.downloaded.map { "\($0)" } ?? "nil")")
                         if count > 20 {
                             Log.artwork.error("Artwork timed out after \(count) attempts; no accessor "
-                                + "(rawData / rawData.get() / data descriptor) yielded a decodable image")
+                                + "(data NSImage / rawData / rawData.get() / data descriptor) yielded an image")
                             self.track.albumArt = NSImage()
                             return
                         }

--- a/Jukebox/ViewModels/ContentViewModel.swift
+++ b/Jukebox/ViewModels/ContentViewModel.swift
@@ -157,7 +157,7 @@ class ContentViewModel: ObservableObject {
                let url = URL(string: artworkURLString) {
                 URLSession.shared.dataTask(with: url) { [weak self] data, response, error in
                     guard let data = data, error == nil else {
-                        print(error!.localizedDescription)
+                        Log.artwork.error("Spotify artwork fetch failed: \(error!.localizedDescription)")
                         return
                     }
                     DispatchQueue.main.async {
@@ -185,17 +185,43 @@ class ContentViewModel: ObservableObject {
             // from the previously playing track. Apple Music delivers artwork
             // data asynchronously, so when artwork exists we poll briefly for the
             // data to arrive — and still clear it if it never materialises.
-            if (self.appleMusicApp?.currentTrack?.artworks?().count ?? 0) == 0 {
+            if let diagnostics = makeAppleMusicTrackDiagnostics() {
+                Log.artwork.debug("Apple Music track: \(diagnostics.description)")
+            }
+            let artworkCount = self.appleMusicApp?.currentTrack?.artworks?().count ?? 0
+            Log.artwork.debug("artworks().count = \(artworkCount)")
+
+            if artworkCount == 0 {
+                Log.artwork.notice("No artwork present for current track; clearing album art")
                 self.track.albumArt = NSImage()
             } else {
                 var count = 0
                 var waitForData: (() -> Void)!
                 waitForData = {
                     let art = self.appleMusicApp?.currentTrack?.artworks?()[0] as! MusicArtwork
-                    if art.data != nil && !art.data!.isEmpty() {
-                        self.track.albumArt = art.data!
+                    let dataImage = art.data
+                    let dataIsEmpty = dataImage?.isEmpty() ?? true
+                    if dataImage != nil && !dataIsEmpty {
+                        Log.artwork.info("Artwork resolved from `data` on attempt \(count) "
+                            + "(size \(Int(dataImage!.size.width))x\(Int(dataImage!.size.height)))")
+                        self.track.albumArt = dataImage!
                     } else {
+                        // Diagnose why `data` is unusable and whether `rawData` has bytes.
+                        let rawDesc: String
+                        switch art.rawData {
+                        case let bytes as Data:   rawDesc = "Data(\(bytes.count) bytes)"
+                        case let bytes as NSData: rawDesc = "NSData(\(bytes.length) bytes)"
+                        case let other?:          rawDesc = "\(type(of: other))"
+                        default:                  rawDesc = "nil"
+                        }
+                        Log.artwork.debug("attempt \(count): "
+                            + "data=\(dataImage == nil ? "nil" : "empty=\(dataIsEmpty)") "
+                            + "format=\(art.format.map { "\($0)" } ?? "nil") "
+                            + "downloaded=\(art.downloaded.map { "\($0)" } ?? "nil") "
+                            + "rawData=\(rawDesc)")
                         if count > 20 {
+                            Log.artwork.error("Artwork timed out after \(count) attempts; "
+                                + "`data` never produced a usable image. rawData=\(rawDesc)")
                             self.track.albumArt = NSImage()
                             return
                         }
@@ -215,9 +241,61 @@ class ContentViewModel: ObservableObject {
         
         // Post notification to update the menu bar track title
         updateMenuBarText()
-        
+
     }
-    
+
+    // MARK: - Diagnostics
+
+    /// Reads the current Apple Music track's source signals via ScriptingBridge.
+    /// Property reads are optional-guarded — an inapplicable property (e.g.
+    /// `location` on a streamed track) returns nil rather than crashing.
+    private func makeAppleMusicTrackDiagnostics() -> TrackDiagnostics? {
+        guard let track = appleMusicApp?.currentTrack else { return nil }
+        let address = (track as? MusicURLTrack)?.address
+        let hasAddress = !(address?.isEmpty ?? true)
+        let hasLocation = (track as? MusicFileTrack)?.location != nil
+        let cloudStatusName = Self.cloudStatusName(track.cloudStatus)
+        let source = TrackDiagnostics.classify(hasAddress: hasAddress,
+                                                hasFileLocation: hasLocation,
+                                                cloudStatus: cloudStatusName)
+        return TrackDiagnostics(
+            sourceType: source,
+            cloudStatus: cloudStatusName,
+            kind: track.kind ?? "",
+            mediaKind: Self.mediaKindName(track.mediaKind),
+            hasLocation: hasLocation,
+            sizeBytes: track.size ?? 0,
+            address: hasAddress ? address : nil)
+    }
+
+    private static func cloudStatusName(_ status: MusicEClS?) -> String {
+        switch status {
+        case .purchased: return "purchased"
+        case .matched: return "matched"
+        case .uploaded: return "uploaded"
+        case .subscription: return "subscription"
+        case .ineligible: return "ineligible"
+        case .removed: return "removed"
+        case .error: return "error"
+        case .duplicate: return "duplicate"
+        case .noLongerAvailable: return "noLongerAvailable"
+        case .notUploaded: return "notUploaded"
+        case .unknown: return "unknown"
+        case .none: return "unavailable"
+        @unknown default: return "unrecognised"
+        }
+    }
+
+    private static func mediaKindName(_ kind: MusicEMdK?) -> String {
+        switch kind {
+        case .song: return "song"
+        case .musicVideo: return "musicVideo"
+        case .unknown: return "unknown"
+        case .none: return "unavailable"
+        @unknown default: return "unrecognised"
+        }
+    }
+
     private func updateMenuBarText(isStopped: Bool = false) {
         DispatchQueue.main.async { [weak self] in
             guard let self, let title = self.track.title as String?,

--- a/Jukebox/ViewModels/ContentViewModel.swift
+++ b/Jukebox/ViewModels/ContentViewModel.swift
@@ -185,11 +185,15 @@ class ContentViewModel: ObservableObject {
             // from the previously playing track. Apple Music delivers artwork
             // data asynchronously, so when artwork exists we poll briefly for the
             // data to arrive — and still clear it if it never materialises.
-            if let diagnostics = makeAppleMusicTrackDiagnostics() {
-                Log.artwork.debug("Apple Music track: \(diagnostics.description)")
+            // These diagnostics make extra ScriptingBridge round-trips purely for
+            // logging, so skip them entirely unless debug logging is enabled.
+            if FileLogSink.shared.isEnabled {
+                if let diagnostics = makeAppleMusicTrackDiagnostics() {
+                    Log.artwork.debug("Apple Music track: \(diagnostics.description)")
+                }
+                let artworkCount = self.appleMusicApp?.currentTrack?.artworks?().count ?? 0
+                Log.artwork.debug("artworks().count = \(artworkCount)")
             }
-            let artworkCount = self.appleMusicApp?.currentTrack?.artworks?().count ?? 0
-            Log.artwork.debug("artworks().count = \(artworkCount)")
 
             // Always poll: Apple Music loads streamed artwork asynchronously, so artworks()
             // is frequently empty (count 0) at the moment of a track change and populates a

--- a/Jukebox/ViewModels/ContentViewModel.swift
+++ b/Jukebox/ViewModels/ContentViewModel.swift
@@ -281,18 +281,26 @@ class ContentViewModel: ObservableObject {
         guard let track = appleMusicApp?.currentTrack else { return nil }
         let address = (track as? MusicURLTrack)?.address
         let hasAddress = !(address?.isEmpty ?? true)
-        let hasLocation = (track as? MusicFileTrack)?.location != nil
+        // On macOS 26.5 streamed Apple Music tracks also report a `location`, so a genuine
+        // local file is distinguished by a file:// URL AND a non-zero byte size — not by the
+        // mere presence of a location.
+        // `location` is doubly-optional here (the @objc-optional member returns URL?),
+        // so collapse URL?? -> URL? before testing the scheme.
+        let locationURL = (track as? MusicFileTrack)?.location ?? nil
+        let hasFileLocation = locationURL?.isFileURL == true
+        let sizeBytes = track.size ?? 0
         let cloudStatusName = Self.cloudStatusName(track.cloudStatus)
         let source = TrackDiagnostics.classify(hasAddress: hasAddress,
-                                                hasFileLocation: hasLocation,
-                                                cloudStatus: cloudStatusName)
+                                                hasFileLocation: hasFileLocation,
+                                                cloudStatus: cloudStatusName,
+                                                sizeBytes: sizeBytes)
         return TrackDiagnostics(
             sourceType: source,
             cloudStatus: cloudStatusName,
             kind: track.kind ?? "",
             mediaKind: Self.mediaKindName(track.mediaKind),
-            hasLocation: hasLocation,
-            sizeBytes: track.size ?? 0,
+            hasLocation: hasFileLocation,
+            sizeBytes: sizeBytes,
             address: hasAddress ? address : nil)
     }
 
@@ -310,8 +318,18 @@ class ContentViewModel: ObservableObject {
         case .notUploaded: return "notUploaded"
         case .unknown: return "unknown"
         case .none: return "unavailable"
-        @unknown default: return "unrecognised"
+        @unknown default: return "unrecognised(\(Self.fourCC(status?.rawValue ?? 0)))"
         }
+    }
+
+    /// Formats a FourCharCode (e.g. a MusicEClS raw value) as a printable tag for logs, so
+    /// an unmapped cloud-status value seen in the field can be identified and mapped.
+    private static func fourCC(_ code: UInt32) -> String {
+        let bytes = [UInt8(truncatingIfNeeded: code >> 24), UInt8(truncatingIfNeeded: code >> 16),
+                     UInt8(truncatingIfNeeded: code >> 8), UInt8(truncatingIfNeeded: code)]
+        let printable = bytes.allSatisfy { $0 >= 0x20 && $0 < 0x7F }
+        let ascii = printable ? "'\(String(bytes: bytes, encoding: .ascii) ?? "")' " : ""
+        return "\(ascii)0x\(String(code, radix: 16))"
     }
 
     private static func mediaKindName(_ kind: MusicEMdK?) -> String {

--- a/Jukebox/ViewModels/ContentViewModel.swift
+++ b/Jukebox/ViewModels/ContentViewModel.swift
@@ -208,35 +208,48 @@ class ContentViewModel: ObservableObject {
                         self.track.albumArt = NSImage()
                         return
                     }
-                    // Build the image from `rawData` (the artwork bytes in their original
-                    // format). The legacy `data` ("picture") property returns a raw
-                    // NSAppleEventDescriptor on macOS 26.5 — NOT an NSImage — so calling any
-                    // NSImage method on it crashes (unrecognized selector) and it never
-                    // yields artwork. `rawData` is the supported path.
-                    let rawBytes: Data?
-                    switch art.rawData {
-                    case let bytes as Data:   rawBytes = bytes
-                    case let bytes as NSData: rawBytes = bytes as Data
-                    default:                  rawBytes = nil
+                    // macOS 26.5: Music's ScriptingBridge artwork accessors don't return
+                    // decoded bytes — `rawData` comes back as an opaque SBObject proxy and
+                    // `data` as a raw NSAppleEventDescriptor. Recover bytes by trying, in order:
+                    // rawData as Data; resolving the rawData proxy via SBObject.get(); the data
+                    // descriptor's payload. Never call NSImage methods on `data` directly
+                    // (it can be an NSAppleEventDescriptor — that crashes 'unrecognized selector').
+                    func imageBytes(_ value: Any?) -> Data? {
+                        switch value {
+                        case let d as Data where !d.isEmpty:     return d
+                        case let d as NSData where d.length > 0: return d as Data
+                        default:                                 return nil
+                        }
                     }
-                    if let bytes = rawBytes, !bytes.isEmpty, let image = NSImage(data: bytes) {
-                        Log.artwork.info("Artwork resolved from `rawData` on attempt \(count) "
-                            + "(\(bytes.count) bytes, \(Int(image.size.width))x\(Int(image.size.height)))")
+                    let rawValue = art.rawData
+                    let dataValue = art.data
+                    let rawDirect = imageBytes(rawValue)
+                    let rawResolved = imageBytes(rawValue.flatMap { $0 as? SBObject }?.get())
+                    let descBytes = dataValue
+                        .flatMap { ($0 as AnyObject) as? NSAppleEventDescriptor }?.data
+                    let descResolved = (descBytes?.isEmpty == false) ? descBytes : nil
+                    let candidates: [(String, Data)] = [
+                        ("rawData", rawDirect),
+                        ("rawData.get()", rawResolved),
+                        ("data-descriptor", descResolved),
+                    ].compactMap { pair in pair.1.map { (pair.0, $0) } }
+                    if let hit = candidates.first(where: { NSImage(data: $0.1) != nil }),
+                       let image = NSImage(data: hit.1) {
+                        Log.artwork.info("Artwork resolved via \(hit.0) on attempt \(count) "
+                            + "(\(hit.1.count) bytes, \(Int(image.size.width))x\(Int(image.size.height)))")
                         self.track.albumArt = image
                     } else {
-                        // Not ready yet (or unavailable). Log the signals, including the
-                        // runtime class of `data`/`rawData` via a SAFE type check — never
-                        // call NSImage methods on `data` (it may be an NSAppleEventDescriptor).
-                        let dataClass = (art.data as AnyObject?).map { "\(type(of: $0))" } ?? "nil"
-                        let rawClass = (art.rawData as AnyObject?).map { "\(type(of: $0))" } ?? "nil"
                         Log.artwork.debug("attempt \(count): "
-                            + "rawData=\(rawBytes.map { "\($0.count) bytes" } ?? "no usable bytes (class \(rawClass))") "
-                            + "data-class=\(dataClass) "
+                            + "rawData=\(rawDirect?.count.description ?? "nil") "
+                            + "rawData.get()=\(rawResolved?.count.description ?? "nil") "
+                            + "data-descriptor=\(descResolved?.count.description ?? "nil") "
+                            + "data-class=\((dataValue as AnyObject?).map { "\(type(of: $0))" } ?? "nil") "
+                            + "rawData-class=\((rawValue as AnyObject?).map { "\(type(of: $0))" } ?? "nil") "
                             + "format=\(art.format.map { "\($0)" } ?? "nil") "
                             + "downloaded=\(art.downloaded.map { "\($0)" } ?? "nil")")
                         if count > 20 {
-                            Log.artwork.error("Artwork timed out after \(count) attempts; "
-                                + "`rawData` never produced a usable image")
+                            Log.artwork.error("Artwork timed out after \(count) attempts; no accessor "
+                                + "(rawData / rawData.get() / data descriptor) yielded a decodable image")
                             self.track.albumArt = NSImage()
                             return
                         }

--- a/Jukebox/Views/NowPlayingCompactView.swift
+++ b/Jukebox/Views/NowPlayingCompactView.swift
@@ -71,6 +71,10 @@ struct NowPlayingCompactView: View {
                 }
                 .padding(Constants.NowPlaying.controlPadding)
                 .opacity((isShowingPlaybackControls && !contentViewVM.isResizing) ? 1 : 0)
+                // Faded-out controls must not receive clicks. The ScrubBar's
+                // zero-distance DragGesture would otherwise commit a seek on a
+                // blind click in the (invisible) lower strip.
+                .allowsHitTesting(isShowingPlaybackControls && !contentViewVM.isResizing)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Jukebox/Views/PreferencesView.swift
+++ b/Jukebox/Views/PreferencesView.swift
@@ -184,7 +184,7 @@ struct PreferencesView: View {
                     Button("Export Logs…") { exportLogs() }
                     Spacer()
                 }
-                Text("Logs include the names of tracks played while logging is enabled.")
+                Text("Logs record playback and artwork diagnostics (and internet-radio stream URLs) — not the names of the tracks you play.")
                     .font(.caption)
                     .foregroundColor(.secondary)
             }

--- a/Jukebox/Views/PreferencesView.swift
+++ b/Jukebox/Views/PreferencesView.swift
@@ -11,12 +11,14 @@ import LaunchAtLogin
 struct PreferencesView: View {
     
     private weak var parentWindow: PreferencesWindow!
-    
+    @ObservedObject private var contentViewVM: ContentViewModel
+
     @AppStorage("visualizerStyle") private var visualizerStyle = VisualizerStyle.albumArt
     @AppStorage("connectedApp") private var connectedApp = ConnectedApps.spotify
     @AppStorage("nowPlayingAlwaysOnTop") private var nowPlayingAlwaysOnTop = false
     @AppStorage("showPlaybackProgress") private var showPlaybackProgress = true
     @AppStorage("animationsEnabled") private var animationsEnabled = true
+    @AppStorage("debugLoggingEnabled") private var debugLoggingEnabled = false
     @State private var alertTitle = Text("Title")
     @State private var alertMessage = Text("Message")
     @State private var showingAlert = false
@@ -25,8 +27,9 @@ struct PreferencesView: View {
         Text(connectedApp.localizedName)
     }
     
-    init(parentWindow: PreferencesWindow) {
+    init(parentWindow: PreferencesWindow, contentViewVM: ContentViewModel) {
         self.parentWindow = parentWindow
+        self.contentViewVM = contentViewVM
     }
     
     // MARK: - Main Body
@@ -168,7 +171,40 @@ struct PreferencesView: View {
                 }
             }
             .padding()
-            
+
+            Divider()
+
+            // Debugging Pane
+            VStack(alignment: .leading) {
+                Text("Debugging")
+                    .font(.title2)
+                    .fontWeight(.semibold)
+                Toggle("Enable debug logging", isOn: $debugLoggingEnabled)
+                HStack {
+                    Button("Export Logs…") { exportLogs() }
+                    Spacer()
+                }
+                Text("Logs include the names of tracks played while logging is enabled.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .padding()
+
+        }
+    }
+
+    private func exportLogs() {
+        switch LogExporter.export(report: contentViewVM.currentDiagnostics()) {
+        case .revealed:
+            break // Finder reveals the file; no alert needed.
+        case .noLogs:
+            alertTitle = Text("No logs yet")
+            alertMessage = Text("Turn on \u{201C}Enable debug logging\u{201D}, reproduce the problem, then export again.")
+            showingAlert = true
+        case .failed(let error):
+            alertTitle = Text("Couldn\u{2019}t export logs")
+            alertMessage = Text(error.localizedDescription)
+            showingAlert = true
         }
     }
     

--- a/Jukebox/Windows/PreferencesWindow.swift
+++ b/Jukebox/Windows/PreferencesWindow.swift
@@ -12,7 +12,7 @@ class PreferencesWindow: NSWindow {
     
     init() {
         super.init(
-            contentRect: NSRect(x: 0, y: 0, width: 400, height: 320),
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 450),
             styleMask: [.titled, .fullSizeContentView],
             backing: .buffered,
             defer: false)

--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ Clicking the button next to the connect option gives you the prompt to connect t
 - 30-second delay before hiding track info after pausing
 - Launch at login support via LaunchAtLogin-Modern
 
+## Debug logging
+
+If you hit a problem (for example, missing album art), you can capture logs to send along
+with a bug report:
+
+1. Open **Preferences ▸ Debugging** and turn on **Enable debug logging**.
+2. Reproduce the problem (e.g. play the track whose artwork is missing).
+3. Click **Export Logs…**. Jukebox writes a `Jukebox-Diagnostics-<timestamp>.txt` file and
+   reveals it in Finder.
+4. Attach that file to your GitHub issue or email.
+
+The log is stored locally at
+`~/Library/Application Support/Jukebox/Logs/Jukebox.log` and is never sent anywhere unless
+you export and share it. It includes the names of tracks played while logging was enabled.
+
 ## Attributions
 
 - [Sparkle](https://sparkle-project.org) for update delivery

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Clicking the button next to the connect option gives you the prompt to connect t
 - **Resizable floating window** — drag any edge to resize the pinned now playing window; it stays square and remembers its size as well as its position
 - **Right-click menu** — right-click the floating window to unpin, toggle "keep on top", open preferences, or quit (the hover pin button has been removed)
 - **Seek from the floating window** — hover to reveal a progress bar you can click or drag to scrub, now working for both Spotify and Apple Music
+- **Debug logging** — a new Debugging pane in Preferences captures diagnostic logs you can export with a bug report (see [Debug logging](#debug-logging) below)
+- **Apple Music artwork on macOS 26** — album art now resolves for streamed Apple Music tracks on macOS 26.5, where the artwork data is delivered differently, with a short retry while it loads asynchronously
+- **Stability fixes** — fixed a crash on macOS 26.5 when reading the location of streamed catalogue tracks, plus a macOS 15 artwork regression and a clipped Preferences window
 
 ### v1.2.1
 
@@ -79,7 +82,8 @@ with a bug report:
 
 The log is stored locally at
 `~/Library/Application Support/Jukebox/Logs/Jukebox.log` and is never sent anywhere unless
-you export and share it. It includes the names of tracks played while logging was enabled.
+you export and share it. It records playback and artwork diagnostics (and, for internet
+radio, the stream URL) — not the names of the tracks you play.
 
 ## Attributions
 

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -3,6 +3,17 @@
     <channel>
         <title>Jukebox</title>
         <item>
+            <title>1.3.0</title>
+            <pubDate>Tue, 16 Jun 2026 20:38:27 +0930</pubDate>
+            <sparkle:version>1.3.0</sparkle:version>
+            <sparkle:shortVersionString>1.3.0</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+            <!-- TODO before publishing: build & sign the release zip, then replace the
+                 length (byte size of Jukebox-1.3.0.zip) and sparkle:edSignature below.
+                 Generate the signature with Sparkle's bin/sign_update Jukebox-1.3.0.zip. -->
+            <enclosure url="https://github.com/jaydenk/Jukebox/releases/download/v1.3.0/Jukebox-1.3.0.zip" length="0" type="application/octet-stream" sparkle:edSignature="REPLACE_WITH_ED_SIGNATURE"/>
+        </item>
+        <item>
             <title>1.2.1</title>
             <pubDate>Tue, 02 Jun 2026 17:10:19 +0930</pubDate>
             <sparkle:version>1.2.1</sparkle:version>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -3,17 +3,6 @@
     <channel>
         <title>Jukebox</title>
         <item>
-            <title>1.3.0</title>
-            <pubDate>Tue, 16 Jun 2026 20:38:27 +0930</pubDate>
-            <sparkle:version>1.3.0</sparkle:version>
-            <sparkle:shortVersionString>1.3.0</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
-            <!-- TODO before publishing: build & sign the release zip, then replace the
-                 length (byte size of Jukebox-1.3.0.zip) and sparkle:edSignature below.
-                 Generate the signature with Sparkle's bin/sign_update Jukebox-1.3.0.zip. -->
-            <enclosure url="https://github.com/jaydenk/Jukebox/releases/download/v1.3.0/Jukebox-1.3.0.zip" length="0" type="application/octet-stream" sparkle:edSignature="REPLACE_WITH_ED_SIGNATURE"/>
-        </item>
-        <item>
             <title>1.2.1</title>
             <pubDate>Tue, 02 Jun 2026 17:10:19 +0930</pubDate>
             <sparkle:version>1.2.1</sparkle:version>

--- a/docs/superpowers/plans/2026-06-15-debug-logging-mode.md
+++ b/docs/superpowers/plans/2026-06-15-debug-logging-mode.md
@@ -1,0 +1,1144 @@
+# Debug Logging Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in debug logging facility — a single `Log` facade fanning out to Apple unified logging plus a size-capped log file users can export — and instrument the Apple Music artwork path to diagnose the empty-album-art bug on macOS 26.5.
+
+**Architecture:** A `Log` enum exposes one category logger each (`general`, `playback`, `artwork`, `permissions`). Each call goes to `os.Logger` (always) and to `FileLogSink` (only when the `debugLoggingEnabled` preference is on). `FileLogSink` wraps a Foundation-only `LogFileWriter` (append + single rollover). "Export Logs…" combines a `DiagnosticsReport` header with the log file and reveals it in Finder. **This plan adds logging only; it does not change artwork-fetch behaviour** (the artwork fix is a separate follow-up informed by the logs).
+
+**Tech Stack:** Swift 5, AppKit + SwiftUI, ScriptingBridge (Music.app), `os.Logger` (unified logging). macOS 13 deployment target. Raw `.xcodeproj` (no XcodeGen/SPM). Pure logic verified by a standalone `swiftc` compile (`scripts/verify-logging.swift`); no test target.
+
+**Spec:** `docs/superpowers/specs/2026-06-15-debug-logging-mode-design.md`
+
+---
+
+## File Structure
+
+New files (flat in `Jukebox/Utilities/`, matching the existing `Constants.swift` / `Helper.swift` / `NSImage+Empty.swift` convention):
+
+- `Jukebox/Utilities/LogLine.swift` — pure: format one log line (UTC ISO-8601 + category + level + message).
+- `Jukebox/Utilities/LogFileWriter.swift` — pure (Foundation-only): append + size-capped single rollover; injected path.
+- `Jukebox/Utilities/TrackSourceType.swift` — pure: `TrackSourceType` enum + `TrackDiagnostics` (raw signals + pure classifier).
+- `Jukebox/Utilities/DiagnosticsReport.swift` — pure: build the export header from injected values.
+- `Jukebox/Utilities/FileLogSink.swift` — singleton: resolves the Application Support path, opt-in gate, owns a `LogFileWriter`.
+- `Jukebox/Utilities/Log.swift` — the facade: per-category `os.Logger` + forward to `FileLogSink`.
+- `Jukebox/Utilities/LogExporter.swift` — combine header + log, write export file, reveal in Finder.
+- `scripts/verify-logging.swift` — standalone verification of the four pure files.
+
+Modified files:
+
+- `Jukebox/Utilities/Constants.swift` — add `Constants.Logging`.
+- `Jukebox/Utilities/Helper.swift` — replace `print()` with `Log.permissions`.
+- `Jukebox/ViewModels/ContentViewModel.swift` — replace `print()`; add Apple Music track diagnostics; instrument the artwork poll; add `currentDiagnostics()`.
+- `Jukebox/Views/PreferencesView.swift` — add a "Debugging" pane (toggle + Export button); accept the view model.
+- `Jukebox/JukeboxApp.swift` — pass `contentViewVM` into `PreferencesView`.
+- `docs/superpowers/specs/2026-06-15-debug-logging-mode-design.md` — sync §7 to the standalone-verify approach.
+- `README.md` — add a "Debug logging" section.
+
+---
+
+## Task 1: Scaffold — create empty source files, add them to the target, set up the verify harness
+
+This is the one bounded project-file change. Creating the files empty up front means later tasks only edit (never re-touch target membership), and the app keeps compiling throughout.
+
+**Files:**
+- Create (empty/stub): the seven `Jukebox/Utilities/Log*.swift` / `TrackSourceType.swift` / `DiagnosticsReport.swift` / `FileLogSink.swift` files listed above.
+- Create: `scripts/verify-logging.swift`
+- Modify (target membership): `Jukebox.xcodeproj/project.pbxproj`
+
+- [ ] **Step 1: Create the seven new source files as minimal stubs**
+
+Each file initially contains only its import so it compiles as an empty translation unit:
+
+`Jukebox/Utilities/LogLine.swift`, `Jukebox/Utilities/LogFileWriter.swift`, `Jukebox/Utilities/TrackSourceType.swift`, `Jukebox/Utilities/DiagnosticsReport.swift`, `Jukebox/Utilities/FileLogSink.swift`:
+```swift
+import Foundation
+```
+
+`Jukebox/Utilities/Log.swift`:
+```swift
+import Foundation
+import os
+```
+
+`Jukebox/Utilities/LogExporter.swift`:
+```swift
+import AppKit
+```
+
+- [ ] **Step 2: Add the seven files to the `Jukebox` target**
+
+The files must be members of the `Jukebox` app target or `xcodebuild` won't compile them.
+
+- **Recommended (interactive):** In Xcode, drag the seven files into the Project Navigator under the existing `Utilities` group, and in the add-sheet ensure **"Jukebox" target is checked** and "Copy items if needed" is unchecked (they already live on disk).
+- **Headless fallback:** add a `PBXFileReference` and a `PBXBuildFile` entry per file to `Jukebox.xcodeproj/project.pbxproj`, add each `PBXFileReference` to the `Utilities` `PBXGroup`'s `children`, and add each `PBXBuildFile` to the `Jukebox` target's `PBXSourcesBuildPhase` `files` list. Mirror the exact pattern already used for `Helper.swift` (grep `Helper.swift` in `project.pbxproj` to see both entries and copy their shape with fresh 24-hex UUIDs).
+
+- [ ] **Step 3: Create the standalone verify harness**
+
+`scripts/verify-logging.swift`:
+```swift
+import Foundation
+
+// Standalone verification of the AppKit-free logging core. Compiled together
+// with the real source files (no copies). Run via:
+//
+//   swiftc Jukebox/Utilities/LogLine.swift \
+//          Jukebox/Utilities/LogFileWriter.swift \
+//          Jukebox/Utilities/TrackSourceType.swift \
+//          Jukebox/Utilities/DiagnosticsReport.swift \
+//          scripts/verify-logging.swift -o /tmp/verify-logging && /tmp/verify-logging
+
+func expect(_ condition: Bool, _ message: String) {
+    if !condition {
+        FileHandle.standardError.write(Data("FAIL: \(message)\n".utf8))
+        exit(1)
+    }
+}
+
+@main
+struct VerifyLogging {
+    static func main() {
+        // Assertions are added by later tasks.
+        print("verify-logging: all checks passed")
+    }
+}
+```
+
+- [ ] **Step 4: Build the app to confirm the stubs compile and are in the target**
+
+Run:
+```bash
+xcodebuild -project Jukebox.xcodeproj -scheme Jukebox -configuration Debug \
+  -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO 2>&1 | tail -5
+```
+Expected: `** BUILD SUCCEEDED **`. (If Swift Package resolution for Sparkle runs on first build, let it finish.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Jukebox/Utilities/LogLine.swift Jukebox/Utilities/LogFileWriter.swift \
+        Jukebox/Utilities/TrackSourceType.swift Jukebox/Utilities/DiagnosticsReport.swift \
+        Jukebox/Utilities/FileLogSink.swift Jukebox/Utilities/Log.swift \
+        Jukebox/Utilities/LogExporter.swift scripts/verify-logging.swift \
+        Jukebox.xcodeproj/project.pbxproj
+git commit -m "Scaffold logging files and standalone verify harness"
+```
+
+---
+
+## Task 2: `LogLine` — pure line formatting
+
+**Files:**
+- Modify: `scripts/verify-logging.swift`
+- Modify: `Jukebox/Utilities/LogLine.swift`
+
+- [ ] **Step 1: Write the failing checks**
+
+In `scripts/verify-logging.swift`, replace the `// Assertions are added by later tasks.` line inside `main()` with:
+```swift
+        // LogLine
+        let fixedDate = Date(timeIntervalSince1970: 1_750_000_000) // 2025-06-15T13:46:40Z
+        let ts = LogLine.timestamp(fixedDate)
+        expect(ts.hasSuffix("Z"), "timestamp must end in Z (UTC), got \(ts)")
+        expect(ts.contains("."), "timestamp must include fractional seconds, got \(ts)")
+        let line = LogLine.format(date: fixedDate, category: "artwork", level: "DEBUG", message: "hello")
+        expect(line.contains("[artwork]"), "line must contain bracketed category, got \(line)")
+        expect(line.contains("DEBUG"), "line must contain level, got \(line)")
+        expect(line.hasSuffix("hello"), "line must end with message, got \(line)")
+```
+
+- [ ] **Step 2: Run the verify to confirm it fails**
+
+Run:
+```bash
+swiftc Jukebox/Utilities/LogLine.swift scripts/verify-logging.swift -o /tmp/verify-logging
+```
+Expected: FAIL — compile error `cannot find 'LogLine' in scope` (the type does not exist yet).
+
+- [ ] **Step 3: Implement `LogLine`**
+
+`Jukebox/Utilities/LogLine.swift`:
+```swift
+import Foundation
+
+/// Pure, AppKit-free formatting of a single log line. Dependency-free so it
+/// can be verified by scripts/verify-logging.swift.
+enum LogLine {
+    /// `2026-06-15T05:18:00.123Z  [category]  LEVEL  message`
+    static func format(date: Date, category: String, level: String, message: String) -> String {
+        return "\(timestamp(date))  [\(category)]  \(level)  \(message)"
+    }
+
+    /// ISO-8601 in UTC, millisecond precision, trailing `Z`.
+    static func timestamp(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        return formatter.string(from: date)
+    }
+}
+```
+
+- [ ] **Step 4: Run the verify to confirm it passes**
+
+Run:
+```bash
+swiftc Jukebox/Utilities/LogLine.swift scripts/verify-logging.swift -o /tmp/verify-logging && /tmp/verify-logging
+```
+Expected: `verify-logging: all checks passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Jukebox/Utilities/LogLine.swift scripts/verify-logging.swift
+git commit -m "Add LogLine pure line formatter"
+```
+
+---
+
+## Task 3: `LogFileWriter` — append + size-capped rollover
+
+**Files:**
+- Modify: `scripts/verify-logging.swift`
+- Modify: `Jukebox/Utilities/LogFileWriter.swift`
+
+- [ ] **Step 1: Write the failing checks**
+
+In `scripts/verify-logging.swift`, add the following inside `main()` immediately before the final `print(...)`:
+```swift
+        // LogFileWriter.shouldRotate (pure)
+        expect(LogFileWriter.shouldRotate(currentBytes: 0, incomingBytes: 100, maxBytes: 50) == false,
+               "empty file must never rotate")
+        expect(LogFileWriter.shouldRotate(currentBytes: 40, incomingBytes: 5, maxBytes: 50) == false,
+               "under cap must not rotate")
+        expect(LogFileWriter.shouldRotate(currentBytes: 48, incomingBytes: 5, maxBytes: 50) == true,
+               "over cap must rotate")
+
+        // LogFileWriter round-trip in a temp dir
+        let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("jukebox-verify-\(UUID().uuidString)", isDirectory: true)
+        let logURL = tmpDir.appendingPathComponent("Jukebox.log")
+        let writer = LogFileWriter(fileURL: logURL, maxBytes: 64)
+        writer.append(String(repeating: "a", count: 50))   // ~51 bytes, under cap
+        expect(FileManager.default.fileExists(atPath: logURL.path), "log file must be created")
+        writer.append(String(repeating: "b", count: 50))   // pushes over cap -> rotates first
+        let rolledURL = logURL.appendingPathExtension("1")
+        expect(FileManager.default.fileExists(atPath: rolledURL.path), "rolled file Jukebox.log.1 must exist")
+        let current = (try? String(contentsOf: logURL, encoding: .utf8)) ?? ""
+        expect(current.contains("b") && !current.contains("a"),
+               "after rotation, current file holds only the newest line")
+        try? FileManager.default.removeItem(at: tmpDir)
+```
+
+- [ ] **Step 2: Run the verify to confirm it fails**
+
+Run:
+```bash
+swiftc Jukebox/Utilities/LogLine.swift Jukebox/Utilities/LogFileWriter.swift \
+  scripts/verify-logging.swift -o /tmp/verify-logging
+```
+Expected: FAIL — compile error `cannot find 'LogFileWriter' in scope`.
+
+- [ ] **Step 3: Implement `LogFileWriter`**
+
+`Jukebox/Utilities/LogFileWriter.swift`:
+```swift
+import Foundation
+
+/// AppKit-free, size-capped append-only log writer with a single rollover.
+/// The path is injected so this type is verifiable in isolation. Not
+/// thread-safe alone; callers serialise access (FileLogSink uses a queue).
+final class LogFileWriter {
+    private let fileURL: URL
+    private let rolledURL: URL
+    private let maxBytes: Int
+    private let fileManager: FileManager
+
+    init(fileURL: URL, maxBytes: Int, fileManager: FileManager = .default) {
+        self.fileURL = fileURL
+        self.rolledURL = fileURL.appendingPathExtension("1") // e.g. Jukebox.log.1
+        self.maxBytes = maxBytes
+        self.fileManager = fileManager
+    }
+
+    /// Appends one line (a trailing newline is added), rotating first if needed.
+    func append(_ line: String) {
+        let data = Data((line + "\n").utf8)
+        ensureFileExists()
+        rotateIfNeeded(incomingBytes: data.count)
+        guard let handle = try? FileHandle(forWritingTo: fileURL) else { return }
+        defer { try? handle.close() }
+        _ = try? handle.seekToEnd()
+        try? handle.write(contentsOf: data)
+    }
+
+    /// Pure rotation decision — extracted so it can be verified directly.
+    static func shouldRotate(currentBytes: Int, incomingBytes: Int, maxBytes: Int) -> Bool {
+        return currentBytes > 0 && currentBytes + incomingBytes > maxBytes
+    }
+
+    private func rotateIfNeeded(incomingBytes: Int) {
+        guard LogFileWriter.shouldRotate(currentBytes: currentBytes(),
+                                         incomingBytes: incomingBytes,
+                                         maxBytes: maxBytes) else { return }
+        try? fileManager.removeItem(at: rolledURL)
+        try? fileManager.moveItem(at: fileURL, to: rolledURL)
+        fileManager.createFile(atPath: fileURL.path, contents: nil)
+    }
+
+    private func ensureFileExists() {
+        let dir = fileURL.deletingLastPathComponent()
+        if !fileManager.fileExists(atPath: dir.path) {
+            try? fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+        if !fileManager.fileExists(atPath: fileURL.path) {
+            fileManager.createFile(atPath: fileURL.path, contents: nil)
+        }
+    }
+
+    private func currentBytes() -> Int {
+        let attrs = try? fileManager.attributesOfItem(atPath: fileURL.path)
+        return (attrs?[.size] as? Int) ?? 0
+    }
+}
+```
+
+- [ ] **Step 4: Run the verify to confirm it passes**
+
+Run:
+```bash
+swiftc Jukebox/Utilities/LogLine.swift Jukebox/Utilities/LogFileWriter.swift \
+  scripts/verify-logging.swift -o /tmp/verify-logging && /tmp/verify-logging
+```
+Expected: `verify-logging: all checks passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Jukebox/Utilities/LogFileWriter.swift scripts/verify-logging.swift
+git commit -m "Add LogFileWriter with size-capped single rollover"
+```
+
+---
+
+## Task 4: `TrackSourceType` — local vs streamed classifier
+
+**Files:**
+- Modify: `scripts/verify-logging.swift`
+- Modify: `Jukebox/Utilities/TrackSourceType.swift`
+
+- [ ] **Step 1: Write the failing checks**
+
+In `scripts/verify-logging.swift`, add inside `main()` before the final `print(...)`:
+```swift
+        // TrackSourceType classifier (pure)
+        expect(TrackDiagnostics.classify(hasAddress: true, hasFileLocation: false, cloudStatus: "unknown") == .internetRadioStream,
+               "an address means internet radio stream")
+        expect(TrackDiagnostics.classify(hasAddress: false, hasFileLocation: true, cloudStatus: "unknown") == .localFile,
+               "a file location means local file")
+        expect(TrackDiagnostics.classify(hasAddress: false, hasFileLocation: false, cloudStatus: "subscription") == .streamed,
+               "subscription with no location means streamed")
+        expect(TrackDiagnostics.classify(hasAddress: false, hasFileLocation: false, cloudStatus: "purchased") == .streamed,
+               "purchased cloud track with no location means streamed")
+        expect(TrackDiagnostics.classify(hasAddress: false, hasFileLocation: false, cloudStatus: "unknown") == .unknown,
+               "no signals means unknown")
+        let diag = TrackDiagnostics(sourceType: .streamed, cloudStatus: "subscription", kind: "Apple Music AAC audio file",
+                                    mediaKind: "song", hasLocation: false, sizeBytes: 0, address: nil)
+        expect(diag.description.contains("source=streamed"), "description must include derived source")
+        expect(diag.description.contains("cloudStatus=subscription"), "description must include cloud status")
+```
+
+- [ ] **Step 2: Run the verify to confirm it fails**
+
+Run:
+```bash
+swiftc Jukebox/Utilities/LogLine.swift Jukebox/Utilities/LogFileWriter.swift \
+  Jukebox/Utilities/TrackSourceType.swift scripts/verify-logging.swift -o /tmp/verify-logging
+```
+Expected: FAIL — compile error `cannot find 'TrackDiagnostics' in scope`.
+
+- [ ] **Step 3: Implement `TrackSourceType` + `TrackDiagnostics`**
+
+`Jukebox/Utilities/TrackSourceType.swift`:
+```swift
+import Foundation
+
+/// Whether the currently-playing track is a local file or streamed.
+enum TrackSourceType: String {
+    case localFile
+    case streamed
+    case internetRadioStream
+    case unknown
+}
+
+/// Raw signals captured from a Music track plus the derived source type.
+/// The classifier is pure (primitive inputs) so it is verifiable in isolation.
+struct TrackDiagnostics {
+    let sourceType: TrackSourceType
+    let cloudStatus: String
+    let kind: String
+    let mediaKind: String
+    let hasLocation: Bool
+    let sizeBytes: Int64
+    let address: String?
+
+    /// Cloud statuses that indicate an Apple Music cloud/catalogue track.
+    private static let cloudStatuses: Set<String> = ["subscription", "purchased", "matched", "uploaded"]
+
+    static func classify(hasAddress: Bool, hasFileLocation: Bool, cloudStatus: String) -> TrackSourceType {
+        if hasAddress { return .internetRadioStream }
+        if hasFileLocation { return .localFile }
+        if cloudStatuses.contains(cloudStatus) { return .streamed }
+        return .unknown
+    }
+
+    /// Single-line, log-friendly summary.
+    var description: String {
+        let addr = address.map { ", address=\($0)" } ?? ""
+        return "source=\(sourceType.rawValue) cloudStatus=\(cloudStatus) kind=\"\(kind)\" "
+            + "mediaKind=\(mediaKind) hasLocation=\(hasLocation) size=\(sizeBytes)\(addr)"
+    }
+}
+```
+
+- [ ] **Step 4: Run the verify to confirm it passes**
+
+Run:
+```bash
+swiftc Jukebox/Utilities/LogLine.swift Jukebox/Utilities/LogFileWriter.swift \
+  Jukebox/Utilities/TrackSourceType.swift scripts/verify-logging.swift -o /tmp/verify-logging && /tmp/verify-logging
+```
+Expected: `verify-logging: all checks passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Jukebox/Utilities/TrackSourceType.swift scripts/verify-logging.swift
+git commit -m "Add TrackSourceType classifier and TrackDiagnostics"
+```
+
+---
+
+## Task 5: `DiagnosticsReport` — export header builder
+
+**Files:**
+- Modify: `scripts/verify-logging.swift`
+- Modify: `Jukebox/Utilities/DiagnosticsReport.swift`
+
+- [ ] **Step 1: Write the failing checks**
+
+In `scripts/verify-logging.swift`, add inside `main()` before the final `print(...)`:
+```swift
+        // DiagnosticsReport header (pure)
+        let report = DiagnosticsReport(
+            appVersion: "1.2.1", osVersion: "Version 26.5", connectedApp: "Apple Music",
+            isRunning: true, permissionStatus: "granted", debugLoggingEnabled: true,
+            currentTrackSource: "source=streamed cloudStatus=subscription",
+            exportedAt: Date(timeIntervalSince1970: 1_750_000_000))
+        let header = report.header()
+        expect(header.contains("1.2.1"), "header must include app version")
+        expect(header.contains("Version 26.5"), "header must include macOS version")
+        expect(header.contains("Apple Music"), "header must include connected app")
+        expect(header.contains("granted"), "header must include permission status")
+        expect(header.contains("source=streamed"), "header must include current track source")
+```
+
+- [ ] **Step 2: Run the verify to confirm it fails**
+
+Run:
+```bash
+swiftc Jukebox/Utilities/LogLine.swift Jukebox/Utilities/LogFileWriter.swift \
+  Jukebox/Utilities/TrackSourceType.swift Jukebox/Utilities/DiagnosticsReport.swift \
+  scripts/verify-logging.swift -o /tmp/verify-logging
+```
+Expected: FAIL — compile error `cannot find 'DiagnosticsReport' in scope`.
+
+- [ ] **Step 3: Implement `DiagnosticsReport`**
+
+`Jukebox/Utilities/DiagnosticsReport.swift`:
+```swift
+import Foundation
+
+/// Builds the human-readable header prepended to an exported log bundle.
+/// Values are injected so the builder is pure and verifiable in isolation.
+struct DiagnosticsReport {
+    let appVersion: String
+    let osVersion: String
+    let connectedApp: String
+    let isRunning: Bool
+    let permissionStatus: String
+    let debugLoggingEnabled: Bool
+    let currentTrackSource: String
+    let exportedAt: Date
+
+    func header() -> String {
+        return """
+        Jukebox Diagnostics
+        ===================
+        Exported:       \(LogLine.timestamp(exportedAt))
+        App version:    \(appVersion)
+        macOS:          \(osVersion)
+        Connected app:  \(connectedApp)
+        App running:    \(isRunning ? "yes" : "no")
+        Automation:     \(permissionStatus)
+        Debug logging:  \(debugLoggingEnabled ? "enabled" : "disabled")
+        Current track:  \(currentTrackSource)
+        """
+    }
+}
+```
+
+- [ ] **Step 4: Run the verify to confirm it passes**
+
+Run:
+```bash
+swiftc Jukebox/Utilities/LogLine.swift Jukebox/Utilities/LogFileWriter.swift \
+  Jukebox/Utilities/TrackSourceType.swift Jukebox/Utilities/DiagnosticsReport.swift \
+  scripts/verify-logging.swift -o /tmp/verify-logging && /tmp/verify-logging
+```
+Expected: `verify-logging: all checks passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Jukebox/Utilities/DiagnosticsReport.swift scripts/verify-logging.swift
+git commit -m "Add DiagnosticsReport export header builder"
+```
+
+---
+
+## Task 6: `Constants.Logging`, `FileLogSink`, and the `Log` facade
+
+These three wire the pure pieces into the app. No standalone test (they touch `UserDefaults`/`os.Logger`); verification is the app build.
+
+**Files:**
+- Modify: `Jukebox/Utilities/Constants.swift`
+- Modify: `Jukebox/Utilities/FileLogSink.swift`
+- Modify: `Jukebox/Utilities/Log.swift`
+
+- [ ] **Step 1: Add `Constants.Logging`**
+
+In `Jukebox/Utilities/Constants.swift`, add this case inside the `enum Constants { … }`, after the `AppleMusic` enum:
+```swift
+    enum Logging {
+        static let subsystem = "com.jaydenkerr.Jukebox"
+        static let enabledKey = "debugLoggingEnabled"
+        static let logFileName = "Jukebox.log"
+        static let maxLogBytes = 5 * 1024 * 1024  // 5 MB; rolls once to Jukebox.log.1
+    }
+```
+
+- [ ] **Step 2: Implement `FileLogSink`**
+
+`Jukebox/Utilities/FileLogSink.swift` (replace the stub):
+```swift
+import Foundation
+
+/// Singleton file sink. Resolves the Application Support log path, gates
+/// writes on the opt-in `debugLoggingEnabled` preference, and serialises
+/// appends on a dedicated queue. Delegates rotation to LogFileWriter.
+final class FileLogSink {
+    static let shared = FileLogSink()
+
+    /// nil if Application Support could not be resolved.
+    let logFileURL: URL?
+    private let writer: LogFileWriter?
+    private let queue = DispatchQueue(label: "\(Constants.Logging.subsystem).filelog", qos: .utility)
+
+    private init() {
+        let url = FileLogSink.defaultLogFileURL()
+        logFileURL = url
+        writer = url.map { LogFileWriter(fileURL: $0, maxBytes: Constants.Logging.maxLogBytes) }
+    }
+
+    private var isEnabled: Bool {
+        UserDefaults.standard.bool(forKey: Constants.Logging.enabledKey)
+    }
+
+    func write(category: String, level: String, message: String) {
+        guard isEnabled, let writer else { return }
+        let line = LogLine.format(date: Date(), category: category, level: level, message: message)
+        queue.async { writer.append(line) }
+    }
+
+    private static func defaultLogFileURL() -> URL? {
+        guard let support = try? FileManager.default.url(
+            for: .applicationSupportDirectory, in: .userDomainMask,
+            appropriateFor: nil, create: true) else { return nil }
+        return support
+            .appendingPathComponent("Jukebox", isDirectory: true)
+            .appendingPathComponent("Logs", isDirectory: true)
+            .appendingPathComponent(Constants.Logging.logFileName)
+    }
+}
+```
+
+- [ ] **Step 3: Implement the `Log` facade**
+
+`Jukebox/Utilities/Log.swift` (replace the stub):
+```swift
+import Foundation
+import os
+
+/// App-wide logging facade. Every call goes to os.Logger (always) and to
+/// FileLogSink (only when debug logging is enabled).
+enum Log {
+    static let general = LogCategory("general")
+    static let playback = LogCategory("playback")
+    static let artwork = LogCategory("artwork")
+    static let permissions = LogCategory("permissions")
+}
+
+struct LogCategory {
+    enum Level: String { case debug = "DEBUG", info = "INFO", notice = "NOTICE", error = "ERROR" }
+
+    let name: String
+    private let logger: Logger
+
+    init(_ name: String) {
+        self.name = name
+        self.logger = Logger(subsystem: Constants.Logging.subsystem, category: name)
+    }
+
+    func debug(_ message: String)  { emit(.debug, message) }
+    func info(_ message: String)   { emit(.info, message) }
+    func notice(_ message: String) { emit(.notice, message) }
+    func error(_ message: String)  { emit(.error, message) }
+
+    private func emit(_ level: Level, _ message: String) {
+        // .public so values are readable in Console.app and exported logs —
+        // this is opt-in diagnostic logging the user chooses to share.
+        switch level {
+        case .debug:  logger.debug("\(message, privacy: .public)")
+        case .info:   logger.info("\(message, privacy: .public)")
+        case .notice: logger.notice("\(message, privacy: .public)")
+        case .error:  logger.error("\(message, privacy: .public)")
+        }
+        FileLogSink.shared.write(category: name, level: level.rawValue, message: message)
+    }
+}
+```
+
+- [ ] **Step 4: Build the app**
+
+Run:
+```bash
+xcodebuild -project Jukebox.xcodeproj -scheme Jukebox -configuration Debug \
+  -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO 2>&1 | tail -5
+```
+Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Jukebox/Utilities/Constants.swift Jukebox/Utilities/FileLogSink.swift Jukebox/Utilities/Log.swift
+git commit -m "Wire Log facade and FileLogSink into the app"
+```
+
+---
+
+## Task 7: Replace existing `print()` calls with the facade
+
+Swap the scattered `print()` debugging for categorised facade calls. Behaviour is unchanged.
+
+**Files:**
+- Modify: `Jukebox/Utilities/Helper.swift`
+- Modify: `Jukebox/ViewModels/ContentViewModel.swift`
+
+- [ ] **Step 1: Update `Helper.swift`**
+
+In `Jukebox/Utilities/Helper.swift`, replace the four `print(...)` lines in the `switch status` block with facade calls (keep the `return` lines unchanged):
+```swift
+        switch status {
+        case -600:
+            Log.permissions.notice("Automation target not open: \(appBundleID)")
+            return .closed
+        case -0:
+            Log.permissions.info("Automation permission granted: \(appBundleID)")
+            return .granted
+        case -1744:
+            Log.permissions.notice("Automation consent required but not prompted: \(appBundleID)")
+            return .notPrompted
+        default:
+            Log.permissions.notice("Automation permission denied: \(appBundleID)")
+            return .denied
+        }
+```
+
+- [ ] **Step 2: Update the non-artwork `print()` calls in `ContentViewModel.swift`**
+
+Make these four replacements:
+
+In `setupMusicApps()`, replace `print("Setting up music apps")` with:
+```swift
+        Log.general.info("Setting up music apps for \(name)")
+```
+
+In `playStateOrTrackDidChange(_:)`, replace `print("The play state or the currently playing track changed")` with:
+```swift
+        Log.playback.debug("Play state or current track changed")
+```
+
+In `getTrackInformation()`, replace `print("Getting track information...")` with:
+```swift
+        Log.playback.debug("Getting track information for \(name)")
+```
+
+In `toggleLoveTrack()` (Spotify case), replace `print("Not supported")` with:
+```swift
+            Log.playback.notice("Love is not supported for Spotify")
+```
+
+- [ ] **Step 3: Build the app**
+
+Run:
+```bash
+xcodebuild -project Jukebox.xcodeproj -scheme Jukebox -configuration Debug \
+  -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO 2>&1 | tail -5
+```
+Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Jukebox/Utilities/Helper.swift Jukebox/ViewModels/ContentViewModel.swift
+git commit -m "Replace scattered print() calls with the Log facade"
+```
+
+---
+
+## Task 8: Apple Music track diagnostics + artwork instrumentation
+
+This is the diagnostic payload that confirms the root cause. **Behaviour is unchanged** — only logging is added around the existing artwork poll.
+
+**Files:**
+- Modify: `Jukebox/ViewModels/ContentViewModel.swift`
+
+- [ ] **Step 1: Add the track-diagnostics builder and enum-name helpers**
+
+In `Jukebox/ViewModels/ContentViewModel.swift`, add these private methods inside the class (e.g. just below `getTrackInformation()`):
+```swift
+    // MARK: - Diagnostics
+
+    /// Reads the current Apple Music track's source signals via ScriptingBridge.
+    /// Property reads are optional-guarded — an inapplicable property (e.g.
+    /// `location` on a streamed track) returns nil rather than crashing.
+    private func makeAppleMusicTrackDiagnostics() -> TrackDiagnostics? {
+        guard let track = appleMusicApp?.currentTrack else { return nil }
+        let address = (track as? MusicURLTrack)?.address
+        let hasAddress = !(address?.isEmpty ?? true)
+        let hasLocation = (track as? MusicFileTrack)?.location != nil
+        let cloudStatusName = Self.cloudStatusName(track.cloudStatus)
+        let source = TrackDiagnostics.classify(hasAddress: hasAddress,
+                                                hasFileLocation: hasLocation,
+                                                cloudStatus: cloudStatusName)
+        return TrackDiagnostics(
+            sourceType: source,
+            cloudStatus: cloudStatusName,
+            kind: track.kind ?? "",
+            mediaKind: Self.mediaKindName(track.mediaKind),
+            hasLocation: hasLocation,
+            sizeBytes: track.size ?? 0,
+            address: hasAddress ? address : nil)
+    }
+
+    private static func cloudStatusName(_ status: MusicEClS?) -> String {
+        switch status {
+        case .purchased: return "purchased"
+        case .matched: return "matched"
+        case .uploaded: return "uploaded"
+        case .subscription: return "subscription"
+        case .ineligible: return "ineligible"
+        case .removed: return "removed"
+        case .error: return "error"
+        case .duplicate: return "duplicate"
+        case .noLongerAvailable: return "noLongerAvailable"
+        case .notUploaded: return "notUploaded"
+        case .unknown: return "unknown"
+        case .none: return "unavailable"
+        @unknown default: return "unrecognised"
+        }
+    }
+
+    private static func mediaKindName(_ kind: MusicEMdK?) -> String {
+        switch kind {
+        case .song: return "song"
+        case .musicVideo: return "musicVideo"
+        case .unknown: return "unknown"
+        case .none: return "unavailable"
+        @unknown default: return "unrecognised"
+        }
+    }
+```
+
+- [ ] **Step 2: Instrument the Apple Music artwork branch**
+
+In `getTrackInformation()`, replace the entire Apple Music album-art block (from the `if (self.appleMusicApp?.currentTrack?.artworks?().count ?? 0) == 0 {` line through the matching closing `}` that ends `waitForData()`) with this instrumented version. The poll timing and the assigned image are identical — only `Log.artwork` calls are added:
+```swift
+            // Album art. A track with no artwork must clear any art left over
+            // from the previously playing track. Apple Music delivers artwork
+            // data asynchronously, so when artwork exists we poll briefly for the
+            // data to arrive — and still clear it if it never materialises.
+            if let diagnostics = makeAppleMusicTrackDiagnostics() {
+                Log.artwork.debug("Apple Music track: \(diagnostics.description)")
+            }
+            let artworkCount = self.appleMusicApp?.currentTrack?.artworks?().count ?? 0
+            Log.artwork.debug("artworks().count = \(artworkCount)")
+
+            if artworkCount == 0 {
+                Log.artwork.notice("No artwork present for current track; clearing album art")
+                self.track.albumArt = NSImage()
+            } else {
+                var count = 0
+                var waitForData: (() -> Void)!
+                waitForData = {
+                    let art = self.appleMusicApp?.currentTrack?.artworks?()[0] as! MusicArtwork
+                    let dataImage = art.data
+                    let dataIsEmpty = dataImage?.isEmpty() ?? true
+                    if dataImage != nil && !dataIsEmpty {
+                        Log.artwork.info("Artwork resolved from `data` on attempt \(count) "
+                            + "(size \(Int(dataImage!.size.width))x\(Int(dataImage!.size.height)))")
+                        self.track.albumArt = dataImage!
+                    } else {
+                        // Diagnose why `data` is unusable and whether `rawData` has bytes.
+                        let rawDesc: String
+                        switch art.rawData {
+                        case let bytes as Data:   rawDesc = "Data(\(bytes.count) bytes)"
+                        case let bytes as NSData: rawDesc = "NSData(\(bytes.length) bytes)"
+                        case let other?:          rawDesc = "\(type(of: other))"
+                        default:                  rawDesc = "nil"
+                        }
+                        Log.artwork.debug("attempt \(count): "
+                            + "data=\(dataImage == nil ? "nil" : "empty=\(dataIsEmpty)") "
+                            + "format=\(art.format.map { "\($0)" } ?? "nil") "
+                            + "downloaded=\(art.downloaded.map { "\($0)" } ?? "nil") "
+                            + "rawData=\(rawDesc)")
+                        if count > 20 {
+                            Log.artwork.error("Artwork timed out after \(count) attempts; "
+                                + "`data` never produced a usable image. rawData=\(rawDesc)")
+                            self.track.albumArt = NSImage()
+                            return
+                        }
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                            waitForData()
+                        }
+                    }
+                    count += 1
+                }
+                waitForData()
+            }
+```
+
+- [ ] **Step 3: Instrument the Spotify artwork error**
+
+In `getTrackInformation()` (Spotify case), replace `print(error!.localizedDescription)` with:
+```swift
+                        Log.artwork.error("Spotify artwork fetch failed: \(error!.localizedDescription)")
+```
+
+- [ ] **Step 4: Build the app**
+
+Run:
+```bash
+xcodebuild -project Jukebox.xcodeproj -scheme Jukebox -configuration Debug \
+  -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO 2>&1 | tail -5
+```
+Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Jukebox/ViewModels/ContentViewModel.swift
+git commit -m "Instrument Apple Music artwork path and track source diagnostics"
+```
+
+---
+
+## Task 9: `currentDiagnostics()` + `LogExporter`
+
+**Files:**
+- Modify: `Jukebox/ViewModels/ContentViewModel.swift`
+- Modify: `Jukebox/Utilities/LogExporter.swift`
+
+- [ ] **Step 1: Add `currentDiagnostics()` to `ContentViewModel`**
+
+In `Jukebox/ViewModels/ContentViewModel.swift`, add inside the class (e.g. below `makeAppleMusicTrackDiagnostics()`):
+```swift
+    /// Snapshot of current app/track state for the exported diagnostics header.
+    func currentDiagnostics() -> DiagnosticsReport {
+        let bundleID = connectedApp == .spotify ? Constants.Spotify.bundleID : Constants.AppleMusic.bundleID
+        let permission = Helper.promptUserForConsent(for: bundleID)
+        let trackSource: String
+        switch connectedApp {
+        case .appleMusic:
+            trackSource = makeAppleMusicTrackDiagnostics()?.description ?? "no track"
+        case .spotify:
+            trackSource = "source=streamed (Spotify)"
+        }
+        return DiagnosticsReport(
+            appVersion: Constants.AppInfo.appVersion ?? "?",
+            osVersion: ProcessInfo.processInfo.operatingSystemVersionString,
+            connectedApp: name,
+            isRunning: isRunning,
+            permissionStatus: Self.permissionName(permission),
+            debugLoggingEnabled: UserDefaults.standard.bool(forKey: Constants.Logging.enabledKey),
+            currentTrackSource: trackSource,
+            exportedAt: Date())
+    }
+
+    private static func permissionName(_ status: Helper.PermissionStatus) -> String {
+        switch status {
+        case .closed: return "app not open"
+        case .granted: return "granted"
+        case .notPrompted: return "not prompted"
+        case .denied: return "denied"
+        }
+    }
+```
+
+- [ ] **Step 2: Implement `LogExporter`**
+
+`Jukebox/Utilities/LogExporter.swift` (replace the stub):
+```swift
+import AppKit
+
+/// Combines the diagnostics header with the log file into a single .txt and
+/// reveals it in Finder for the user to send.
+enum LogExporter {
+    enum Outcome {
+        case revealed(URL)
+        case noLogs
+        case failed(Error)
+    }
+
+    static func export(report: DiagnosticsReport) -> Outcome {
+        guard let logURL = FileLogSink.shared.logFileURL,
+              let logText = try? String(contentsOf: logURL, encoding: .utf8),
+              !logText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return .noLogs
+        }
+        let combined = report.header() + "\n\n===== LOG =====\n\n" + logText
+        let exportURL = logURL.deletingLastPathComponent()
+            .appendingPathComponent("Jukebox-Diagnostics-\(fileTimestamp(report.exportedAt)).txt")
+        do {
+            try combined.write(to: exportURL, atomically: true, encoding: .utf8)
+            NSWorkspace.shared.activateFileViewerSelecting([exportURL])
+            return .revealed(exportURL)
+        } catch {
+            return .failed(error)
+        }
+    }
+
+    private static func fileTimestamp(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        return formatter.string(from: date)
+    }
+}
+```
+
+- [ ] **Step 3: Build the app**
+
+Run:
+```bash
+xcodebuild -project Jukebox.xcodeproj -scheme Jukebox -configuration Debug \
+  -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO 2>&1 | tail -5
+```
+Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Jukebox/ViewModels/ContentViewModel.swift Jukebox/Utilities/LogExporter.swift
+git commit -m "Add currentDiagnostics() and LogExporter"
+```
+
+---
+
+## Task 10: Preferences "Debugging" pane
+
+**Files:**
+- Modify: `Jukebox/Views/PreferencesView.swift`
+- Modify: `Jukebox/JukeboxApp.swift`
+
+- [ ] **Step 1: Thread the view model into `PreferencesView`**
+
+In `Jukebox/Views/PreferencesView.swift`:
+
+Add an `@AppStorage` property alongside the existing ones (after `@AppStorage("animationsEnabled") private var animationsEnabled = true`):
+```swift
+    @AppStorage("debugLoggingEnabled") private var debugLoggingEnabled = false
+```
+
+Add a stored view model property after `private weak var parentWindow: PreferencesWindow!`:
+```swift
+    @ObservedObject private var contentViewVM: ContentViewModel
+```
+
+Replace the initialiser:
+```swift
+    init(parentWindow: PreferencesWindow) {
+        self.parentWindow = parentWindow
+    }
+```
+with:
+```swift
+    init(parentWindow: PreferencesWindow, contentViewVM: ContentViewModel) {
+        self.parentWindow = parentWindow
+        self.contentViewVM = contentViewVM
+    }
+```
+
+- [ ] **Step 2: Add the Debugging pane and export action**
+
+In `preferencePanes`, after the closing `}` of the `// Visualizer Pane` `VStack { … }.padding()` (the last pane), add:
+```swift
+
+            Divider()
+
+            // Debugging Pane
+            VStack(alignment: .leading) {
+                Text("Debugging")
+                    .font(.title2)
+                    .fontWeight(.semibold)
+                Toggle("Enable debug logging", isOn: $debugLoggingEnabled)
+                HStack {
+                    Button("Export Logs…") { exportLogs() }
+                    Spacer()
+                }
+                Text("Logs include the names of tracks played while logging is enabled.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .padding()
+```
+
+Add the export action method inside the `struct PreferencesView` (e.g. after `preferencePanes`):
+```swift
+    private func exportLogs() {
+        switch LogExporter.export(report: contentViewVM.currentDiagnostics()) {
+        case .revealed:
+            break // Finder reveals the file; no alert needed.
+        case .noLogs:
+            alertTitle = Text("No logs yet")
+            alertMessage = Text("Turn on \u{201C}Enable debug logging\u{201D}, reproduce the problem, then export again.")
+            showingAlert = true
+        case .failed(let error):
+            alertTitle = Text("Couldn\u{2019}t export logs")
+            alertMessage = Text(error.localizedDescription)
+            showingAlert = true
+        }
+    }
+```
+
+- [ ] **Step 3: Pass the view model when creating the view**
+
+In `Jukebox/JukeboxApp.swift`, in `showPreferences(_:)`, replace:
+```swift
+            let hostedPrefView = NSHostingView(rootView: PreferencesView(parentWindow: preferencesWindow))
+```
+with:
+```swift
+            let hostedPrefView = NSHostingView(rootView: PreferencesView(parentWindow: preferencesWindow, contentViewVM: contentViewVM))
+```
+
+- [ ] **Step 4: Build the app**
+
+Run:
+```bash
+xcodebuild -project Jukebox.xcodeproj -scheme Jukebox -configuration Debug \
+  -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO 2>&1 | tail -5
+```
+Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Jukebox/Views/PreferencesView.swift Jukebox/JukeboxApp.swift
+git commit -m "Add Debugging preferences pane with log export"
+```
+
+---
+
+## Task 11: Docs sync + manual verification
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-06-15-debug-logging-mode-design.md`
+- Modify: `README.md`
+
+- [ ] **Step 1: Sync the spec's testing section**
+
+In `docs/superpowers/specs/2026-06-15-debug-logging-mode-design.md`, in section **7. Testing**, replace the "Unit tests (pure pieces, no AppKit)" bullet's lead-in to state the chosen mechanism. Replace:
+```markdown
+- **Unit tests (pure pieces, no AppKit):**
+```
+with:
+```markdown
+- **Verification of pure pieces (standalone `swiftc`, no test target):** `scripts/verify-logging.swift`
+  is compiled together with the real `LogLine`, `LogFileWriter`, `TrackSourceType`, and
+  `DiagnosticsReport` source files (no copies) and run as an executable. It asserts:
+```
+
+- [ ] **Step 2: Add a "Debug logging" section to the README**
+
+In `README.md`, add a new section (place it after the existing usage/features content, before any licence/credits footer):
+```markdown
+## Debug logging
+
+If you hit a problem (for example, missing album art), you can capture logs to send along
+with a bug report:
+
+1. Open **Preferences ▸ Debugging** and turn on **Enable debug logging**.
+2. Reproduce the problem (e.g. play the track whose artwork is missing).
+3. Click **Export Logs…**. Jukebox writes a `Jukebox-Diagnostics-<timestamp>.txt` file and
+   reveals it in Finder.
+4. Attach that file to your GitHub issue or email.
+
+The log is stored locally at
+`~/Library/Application Support/Jukebox/Logs/Jukebox.log` and is never sent anywhere unless
+you export and share it. It includes the names of tracks played while logging was enabled.
+```
+
+- [ ] **Step 3: Commit the docs**
+
+```bash
+git add docs/superpowers/specs/2026-06-15-debug-logging-mode-design.md README.md
+git commit -m "Document debug logging and sync spec testing approach"
+```
+
+- [ ] **Step 4: Manual verification (the real point — diagnose the artwork bug)**
+
+1. Run the app from Xcode (so you can also watch the live stream):
+   `log stream --predicate 'subsystem == "com.jaydenkerr.Jukebox"' --level debug` in Terminal.
+2. Connect to **Apple Music** and grant automation permission if prompted.
+3. In **Preferences ▸ Debugging**, enable **Enable debug logging**.
+4. Play an Apple Music **streamed** track whose artwork shows as an empty grey square.
+5. Click **Export Logs…**, open the revealed `.txt`, and inspect the `[artwork]` lines. Confirm:
+   - the track logs `source=streamed cloudStatus=subscription` (or similar), and
+   - the poll logs show `data=nil` (or `empty=true`) **while** `rawData=Data(NNNN bytes)` is non-empty,
+   - ending in `Artwork timed out after 21 attempts`.
+6. That combination confirms the root cause (legacy `data` property fails for cloud artwork
+   while `rawData` carries the real bytes) and is the evidence for the follow-up artwork fix.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- §3 architecture (facade + two sinks) → Tasks 2–6.
+- §4.1 facade, four categories, `.public` privacy → Task 6 (`Log.swift`).
+- §4.2 file sink: AppSupport path, opt-in gate, UTC-`Z` format, ~5 MB single rollover, serialised queue → Tasks 3 (`LogFileWriter`) + 6 (`FileLogSink`, `Constants.Logging`).
+- §4.3 track source-type + raw signals → Task 4 (pure) + Task 8 (ScriptingBridge builder + enum-name maps).
+- §4.4 instrumentation (artwork detail, Spotify error, lifecycle/permissions) → Tasks 7 + 8.
+- §4.5 diagnostics header + single-`.txt` export + reveal in Finder → Tasks 5 + 9.
+- §4.6 Debugging preferences pane (toggle, Export button, caption, no-logs alert) → Task 10.
+- §5 privacy (local-only, disclosed in caption + header) → Tasks 10 + 5.
+- §6 error handling (swallow file I/O, no-logs alert, optional-guarded SB reads) → Tasks 3, 8, 9, 10.
+- §7 testing (standalone verify of pure pieces + manual verification) → Tasks 2–5 + 11.
+- §8 out of scope (artwork fix deferred) → stated in plan goal + Task 11 step 6.
+
+**Placeholder scan:** No `TBD`/`TODO`/"handle edge cases"; every code step shows complete code; every command shows expected output. ✓
+
+**Type consistency:** `LogLine.format`/`LogLine.timestamp`, `LogFileWriter.shouldRotate(currentBytes:incomingBytes:maxBytes:)`, `TrackDiagnostics.classify(hasAddress:hasFileLocation:cloudStatus:)`, `DiagnosticsReport(...).header()`, `FileLogSink.shared.logFileURL` / `.write(category:level:message:)`, `Log.<category>.<level>(_:)`, `LogExporter.export(report:) -> LogExporter.Outcome`, and `ContentViewModel.currentDiagnostics() -> DiagnosticsReport` are used consistently across the tasks that define and call them. ✓

--- a/docs/superpowers/specs/2026-06-15-debug-logging-mode-design.md
+++ b/docs/superpowers/specs/2026-06-15-debug-logging-mode-design.md
@@ -1,0 +1,219 @@
+# Debug Logging Mode — Design
+
+- **Date:** 2026-06-15
+- **Status:** Approved (design) — pending implementation plan
+- **Author:** Jayden Kerr (with Claude)
+- **Branch context:** `feature/floating-window-enhancements`
+
+## 1. Background and motivation
+
+While testing the Apple Music integration on macOS 26.5, playback progress works but
+album art renders as an empty grey square, with nothing useful in the console. The app's
+only diagnostics today are bare `print()` calls scattered through `ContentViewModel` and
+`Helper`, which:
+
+- go to stdout and are therefore invisible in a shipped build a user is running, and
+- have **no failure-path logging** on the artwork code (the artwork poll loop silently
+  assigns `NSImage()` on timeout), so there is genuinely nothing to observe.
+
+We need a real debug-logging facility that serves two purposes:
+
+1. **Diagnosis** — confirm the root cause of the missing album art (and future issues).
+2. **Support** — let users send us logs when they hit a problem.
+
+### Root-cause hypothesis (to confirm, not to fix here)
+
+Jukebox talks to Music.app via **ScriptingBridge**, not MusicKit. The Apple Music artwork
+path (`ContentViewModel.getTrackInformation()`) reads `art.data`
+(`MusicApplication.swift`: `data: NSImage // ...in the form of a picture`). The interface
+also exposes `rawData: Any // ...in original format`. On recent macOS, Music's legacy
+`data` ("picture") property frequently returns nil/empty while `rawData` (the real
+JPEG/PNG bytes) still works.
+
+**This design adds logging only. It does NOT change artwork-fetch behaviour.** The logging
+is the instrument that will confirm or refute the `data`-vs-`rawData` theory. The artwork
+fix is a separate follow-up, informed by what the logs show. This keeps us honest to
+"diagnose the root cause before applying a fix".
+
+## 2. Goals / non-goals
+
+**Goals**
+
+- A single logging facade used throughout the app.
+- Live stream viewable during development (Apple unified logging / Console.app).
+- An opt-in, persisted log file users can export and send us.
+- One-click "Export Logs…" that produces a single self-contained file and reveals it in
+  Finder.
+- Rich instrumentation of the artwork path, including a derived **track source type**
+  (local file vs streamed) and the raw signals behind it.
+
+**Non-goals (YAGNI)**
+
+- Remote or automatic log upload; crash reporting; network telemetry.
+- Multiple verbosity levels exposed in the UI (one opt-in toggle only).
+- GitHub-API issue creation, share sheet, clipboard copy (explicitly deferred — only
+  "save + reveal in Finder" was chosen).
+- An in-app log viewer.
+- The artwork **fix** itself.
+
+## 3. Architecture
+
+A lightweight **logging facade** — a `Log` type — fans out every call to two sinks:
+
+1. `os.Logger` (Apple unified logging) — **always**.
+2. A file writer (`FileLogSink`) — **only when the user opts in**.
+
+Call sites look like ordinary unified-logging calls: `Log.artwork.debug("…")`. They never
+know there are two sinks.
+
+*Rejected alternative:* a protocol-based `Logging` abstraction with injectable sinks. More
+testable in theory, but it is ceremony this single-app codebase does not need; the facade
+still exposes its pure pieces (line formatting, rotation, header generation) for unit
+testing. The enum-of-loggers shape matches the existing `Constants` / `Helper` style.
+
+### 3.1 Components and responsibilities
+
+| Unit | Responsibility | Depends on |
+| --- | --- | --- |
+| `Log` (enum) | One `Logger` per category; forwards to `os.Logger` + `FileLogSink`. | `os.Logger`, `FileLogSink` |
+| `FileLogSink` (final class, singleton) | Serialised append-to-file, opt-in gating, size-capped rotation. | `FileManager`, a private `DispatchQueue` |
+| `LogLine` (struct/formatter) | Pure formatting of one line (timestamp, category, level, message). | Foundation only |
+| `DiagnosticsReport` (struct) | Build the export header from injected values. | injected values only |
+| `LogExporter` | Combine header + log file into one export file; reveal in Finder. | `FileLogSink`, `DiagnosticsReport`, `NSWorkspace` |
+| `TrackSourceType` (enum + classifier) | Derive local/streamed/etc. from track signals. | `MusicTrack` accessors |
+| Debugging preference pane | Toggle + "Export Logs…" button. | `@AppStorage`, `LogExporter` |
+
+Each unit is understandable and testable in isolation; the AppKit-touching pieces
+(`LogExporter`, the pane) are thin shells over the pure pieces.
+
+## 4. Detailed design
+
+### 4.1 The `Log` facade
+
+- Subsystem: `com.jaydenkerr.Jukebox` (the bundle identifier).
+- Categories (four — enough to filter usefully without over-categorising):
+  - `general` — lifecycle, app/connection setup, miscellaneous.
+  - `playback` — play/pause/track-change events, seeker/position.
+  - `artwork` — artwork retrieval (the bug surface).
+  - `permissions` — automation-consent results.
+- Levels: `.debug`, `.info`, `.notice`, `.error`. `os.Logger` receives all of them, so a
+  developer can `log stream --predicate 'subsystem == "com.jaydenkerr.Jukebox"'` or filter
+  Console.app live with no toggle. The file sink only persists when enabled.
+- Privacy: because this is opt-in diagnostic logging the user chooses to share, dynamic
+  values we want to see (track title/artist, byte counts, status) are interpolated
+  `.public` in the `os.Logger` calls. The file sink performs no redaction.
+
+### 4.2 `FileLogSink`
+
+- File: `~/Library/Application Support/Jukebox/Logs/Jukebox.log`, resolved via
+  `FileManager.default.url(for: .applicationSupportDirectory, …)` so it is correct whether
+  or not the app is sandboxed. The `Logs` directory is created on first write.
+- **Opt-in gate:** writes occur only when `@AppStorage("debugLoggingEnabled")` is `true`.
+  Off by default. When on, the file captures full detail (all levels).
+- **Format** (one line):
+  `2026-06-15T14:48:00.123Z  [artwork]  DEBUG  message`
+  Timestamps are stored in **UTC** with a trailing `Z` (per the project's UTC-storage
+  rule), to milliseconds, followed by category and level.
+- **Rotation:** a single file capped at ~5 MB. On exceeding the cap, roll once to
+  `Jukebox.log.1` (overwriting any previous `.1`) and start a fresh `Jukebox.log`. Disk
+  use is bounded to ~10 MB.
+- **Concurrency:** all writes are serialised on a dedicated `DispatchQueue` so logging
+  from the artwork poll, timers, and distributed-notification handlers cannot interleave
+  or race.
+
+### 4.3 Track source-type classification
+
+A `TrackSourceType` derived from real `MusicTrack` signals (verified against the
+ScriptingBridge interface):
+
+- `internetRadioStream` — `MusicURLTrack.address` is non-empty.
+- `localFile` — a file `location` URL is present (`MusicFileTrack`/`MusicAudioCDTrack`).
+- `streamed` — no `location`; an Apple Music cloud/catalogue track.
+- `unknown` — none of the above resolves.
+
+Logged **alongside the derived label**, we record the raw inputs so the classification is
+auditable and future-proof:
+
+- `cloudStatus` (`MusicEClS`) mapped to a name — notably `.subscription` (Apple Music
+  stream), `.purchased` / `.matched` / `.uploaded` (iCloud Music Library), `.unknown`.
+- `kind` (the localised string, e.g. "Apple Music AAC audio file").
+- `mediaKind` (`MusicEMdK`: song / musicVideo / unknown).
+- `hasLocation` (and whether the URL scheme is `file`).
+- `size` (bytes; streamed catalogue tracks typically report 0).
+
+Property reads are guarded as optionals — accessing an inapplicable ScriptingBridge
+property (e.g. `location` on a streamed track) returns nil rather than crashing.
+
+### 4.4 Instrumentation plan (where log calls go)
+
+- **Artwork path** (`getTrackInformation`, Apple Music branch) — the payload that confirms
+  the root cause. For the current track, log: source type + raw signals (4.3);
+  `artworks().count`; and for `art[0]`: whether `data` is nil, whether `data.isEmpty()`,
+  plus `format`, `downloaded`, `kind`; and crucially the **`rawData` class name and byte
+  count**. Log each poll attempt number and the final outcome (got data at attempt N /
+  timed out after 21 attempts / no artwork present).
+- **Spotify artwork** — log artwork-URL fetch success/failure (currently a bare
+  `print(error.localizedDescription)`).
+- **Lifecycle / playback / permissions** — replace existing scattered `print()` calls
+  (`"Setting up music apps"`, `"Getting track information..."`, `Helper`'s permission
+  prints) with categorised facade calls, so nothing useful is lost and stdout noise
+  becomes structured, filterable logging.
+
+### 4.5 Diagnostics header + export
+
+- `DiagnosticsReport` builds a header from injected values: app version
+  (`Constants.AppInfo.appVersion`), `macOS \(ProcessInfo.processInfo.operatingSystemVersionString)`,
+  connected app, is-running, automation-permission status (reusing
+  `Helper.promptUserForConsent`), whether debug logging is enabled, current track's source
+  type, and an export timestamp.
+- **"Export Logs…"** (`LogExporter`) writes a single combined
+  `Jukebox-Diagnostics-YYYYMMDD-HHmmss.txt` (header + the full log file) into the `Logs`
+  folder, then calls `NSWorkspace.shared.activateFileViewerSelecting([url])` to reveal it
+  selected in Finder. One file; no zip; no network. The user drags it into an email or
+  GitHub issue.
+- If logging was never enabled or the log is empty, the button shows the existing
+  SwiftUI `Alert` style telling the user to enable debug logging and reproduce first.
+
+### 4.6 Preferences UI — new "Debugging" pane
+
+A third pane below "Background" in `PreferencesView.preferencePanes`, matching the existing
+style (a titled `VStack` of controls):
+
+- `Toggle("Enable debug logging", isOn: $debugLoggingEnabled)` (`@AppStorage`).
+- `Button("Export Logs…")` → `LogExporter`.
+- A one-line caption: the log includes the names of tracks played while logging was
+  enabled (transparency about what is being shared).
+
+## 5. Privacy
+
+The log file stays local and is never transmitted by the app; it leaves only when the user
+explicitly exports and sends it. It contains the titles/artists of tracks played while
+logging was enabled — disclosed both in the Preferences caption and the export header. No
+redaction beyond that (the values are the point of a diagnostic log).
+
+## 6. Error handling
+
+- File I/O failures (cannot create `Logs` dir, cannot write) are swallowed for the file
+  sink but still reported via `os.Logger` at `.error`, so logging never crashes or blocks
+  the app.
+- Export with no/empty log → user-facing alert (see 4.5), not an error.
+- ScriptingBridge property reads are optional-guarded (see 4.3).
+
+## 7. Testing
+
+- **Unit tests (pure pieces, no AppKit):**
+  - `FileLogSink` rotation: write past the cap → rolls to `.1`, fresh file started,
+    bounded total size.
+  - `LogLine` formatting: timestamp/category/level/message shape is stable.
+  - `DiagnosticsReport` header generation from injected values.
+  - `TrackSourceType` classifier: each branch (address / location / subscription / unknown)
+    from representative inputs.
+- **Manual verification:** enable the toggle, play an Apple Music **streamed** track with
+  missing art, export, read the file, and confirm whether `data` is empty while `rawData`
+  carries bytes — and whether the failure correlates with `cloudStatus == .subscription`.
+
+## 8. Out of scope / follow-ups
+
+- The artwork **fix** (likely switching the Apple Music path to `rawData`), to be designed
+  once the logs confirm the cause.
+- Any of the deferred export channels (share sheet, clipboard, GitHub issue).

--- a/docs/superpowers/specs/2026-06-15-debug-logging-mode-design.md
+++ b/docs/superpowers/specs/2026-06-15-debug-logging-mode-design.md
@@ -201,8 +201,10 @@ redaction beyond that (the values are the point of a diagnostic log).
 
 ## 7. Testing
 
-- **Unit tests (pure pieces, no AppKit):**
-  - `FileLogSink` rotation: write past the cap → rolls to `.1`, fresh file started,
+- **Verification of pure pieces (standalone `swiftc`, no test target):** `scripts/verify-logging.swift`
+  is compiled together with the real `LogLine`, `LogFileWriter`, `TrackSourceType`, and
+  `DiagnosticsReport` source files (no copies) and run as an executable. It asserts:
+  - `LogFileWriter` rotation: write past the cap → rolls to `.1`, fresh file started,
     bounded total size.
   - `LogLine` formatting: timestamp/category/level/message shape is stable.
   - `DiagnosticsReport` header generation from injected values.

--- a/docs/superpowers/specs/2026-06-15-debug-logging-mode-design.md
+++ b/docs/superpowers/specs/2026-06-15-debug-logging-mode-design.md
@@ -1,9 +1,9 @@
 # Debug Logging Mode — Design
 
 - **Date:** 2026-06-15
-- **Status:** Approved (design) — pending implementation plan
+- **Status:** Implemented and shipped on `feature/debug-logging` (PR #4). Scope grew during on-device verification — see the Addendum (§9).
 - **Author:** Jayden Kerr (with Claude)
-- **Branch context:** `feature/floating-window-enhancements`
+- **Branch context:** implemented on `feature/debug-logging` (stacked on `feature/floating-window-enhancements`)
 
 ## 1. Background and motivation
 
@@ -34,6 +34,10 @@ JPEG/PNG bytes) still works.
 is the instrument that will confirm or refute the `data`-vs-`rawData` theory. The artwork
 fix is a separate follow-up, informed by what the logs show. This keeps us honest to
 "diagnose the root cause before applying a fix".
+
+> **Superseded (2026-06-16):** on-device verification on macOS 26.5 confirmed the cause and
+> surfaced several ScriptingBridge breakages, so the artwork fix (and the crashes it exposed)
+> landed in this same branch rather than as a later follow-up. See the Addendum (§9).
 
 ## 2. Goals / non-goals
 
@@ -219,3 +223,35 @@ redaction beyond that (the values are the point of a diagnostic log).
 - The artwork **fix** (likely switching the Apple Music path to `rawData`), to be designed
   once the logs confirm the cause.
 - Any of the deferred export channels (share sheet, clipboard, GitHub issue).
+
+## 9. Addendum — on-device verification on macOS 26.5 (2026-06-16)
+
+On-device testing on macOS 26.5 (build 25F80) confirmed the root cause and surfaced a chain
+of ScriptingBridge breakages specific to that OS. Because each blocked the next, the artwork
+fix that §1 deferred — plus the crashes it exposed — shipped on this branch rather than as a
+later follow-up. What landed beyond the logging feature:
+
+1. **`location` crash (`EXC_BREAKPOINT`).** The diagnostics read `MusicFileTrack.location`,
+   declared non-optional `URL`; for a streamed track the missing value bridges nil into the
+   non-optional value type and traps. Fixed by typing `location` as `URL?` in the generated
+   ScriptingBridge header.
+2. **`data` crash (`unrecognized selector`).** `MusicArtwork.data` (declared `NSImage`)
+   returns an `NSAppleEventDescriptor` at runtime; `NSImage.isEmpty()` → `cgImage(...)` on it
+   crashed. Stopped calling NSImage methods on `data`.
+3. **Artwork fix (resolves the original empty-grey-square bug).** Both `data` (→ descriptor)
+   and `rawData` (→ opaque `SBObject` proxy) fail to yield bytes through ScriptingBridge on
+   26.5. Album art is now recovered by resolving the `rawData` proxy via `SBObject.get()`
+   and/or reading the `data` descriptor's payload (`NSAppleEventDescriptor.data`), then
+   `NSImage(data:)`.
+4. **`SBElementArray.first` returns nil** even when `count > 0` (lazy faulting-proxy
+   collection); reverted to the `[0]` subscript and made the guard log on miss.
+5. **Track source-type misclassification.** Streamed Apple Music tracks report a `location`
+   and `size == 0` on 26.5 (and `cloudStatus` bridges to `unrecognised`), so the
+   `hasLocation → localFile` heuristic was wrong. Now size-based: a local file needs a
+   `file://` location **and** `size > 0`; `size == 0` ⇒ streamed.
+
+These macOS-26.5 ScriptingBridge findings were captured as reusable gotchas in the
+`swift-gotchas` skill (items 6–10).
+
+Still genuinely deferred: the alternative export channels (share sheet, clipboard, GitHub
+issue) and an AVFoundation embedded-artwork path for local files.

--- a/docs/superpowers/specs/2026-06-15-debug-logging-mode-design.md
+++ b/docs/superpowers/specs/2026-06-15-debug-logging-mode-design.md
@@ -238,20 +238,34 @@ later follow-up. What landed beyond the logging feature:
 2. **`data` crash (`unrecognized selector`).** `MusicArtwork.data` (declared `NSImage`)
    returns an `NSAppleEventDescriptor` at runtime; `NSImage.isEmpty()` → `cgImage(...)` on it
    crashed. Stopped calling NSImage methods on `data`.
-3. **Artwork fix (resolves the original empty-grey-square bug).** Both `data` (→ descriptor)
-   and `rawData` (→ opaque `SBObject` proxy) fail to yield bytes through ScriptingBridge on
-   26.5. Album art is now recovered by resolving the `rawData` proxy via `SBObject.get()`
-   and/or reading the `data` descriptor's payload (`NSAppleEventDescriptor.data`), then
-   `NSImage(data:)`.
-4. **`SBElementArray.first` returns nil** even when `count > 0` (lazy faulting-proxy
+3. **Artwork fix — cross-OS resolver (resolves the original empty-grey-square bug).** Music's
+   artwork accessors behave differently per OS: on **macOS ≤15** `MusicArtwork.data` is a
+   genuine `NSImage` (and `rawData`/descriptor return nothing), whereas on **macOS 26.5** `data`
+   is an `NSAppleEventDescriptor` and `rawData` an opaque `SBObject` proxy. The resolver now
+   tries, in order: `data`-as-`NSImage` (safe on 26.5 — a descriptor fails the cast and falls
+   through), then `rawData` bytes, then the resolved `rawData` proxy via `SBObject.get()`, then
+   the `data` descriptor payload (`NSAppleEventDescriptor.data`), then `NSImage(data:)`. Verified
+   on both OSes with correct per-track covers (macOS 15 via `data(NSImage)`, 26.5 via
+   `data-descriptor`).
+4. **Async artwork loading.** Apple Music populates `artworks()` asynchronously, so `count` is
+   often 0 right at a track change. The poll now retries on `count == 0` (clearing stale art on
+   the first miss, timing out after ~5 s) instead of bailing immediately.
+5. **`SBElementArray.first` returns nil** even when `count > 0` (lazy faulting-proxy
    collection); reverted to the `[0]` subscript and made the guard log on miss.
-5. **Track source-type misclassification.** Streamed Apple Music tracks report a `location`
+6. **Track source-type misclassification.** Streamed Apple Music tracks report a `location`
    and `size == 0` on 26.5 (and `cloudStatus` bridges to `unrecognised`), so the
    `hasLocation → localFile` heuristic was wrong. Now size-based: a local file needs a
    `file://` location **and** `size > 0`; `size == 0` ⇒ streamed.
+7. **Preferences window clipped.** The new Debugging pane overflowed the fixed 320 pt window
+   (clipping "Export Logs…"); window height raised to 450 pt.
+8. **Popover layout differed across OSes.** On macOS 26 `NSPopover` ignored `contentSize` and
+   the host `NSHostingView.sizingOptions`, rendering larger than the macOS 15 layout; fixed by
+   setting `contentViewController.preferredContentSize`.
 
-These macOS-26.5 ScriptingBridge findings were captured as reusable gotchas in the
-`swift-gotchas` skill (items 6–10).
+These findings were captured as reusable gotchas: `swift-gotchas` items 6–11 (the
+ScriptingBridge/artwork chain) and `appkit-gotchas` (the NSPopover-sizing one).
 
-Still genuinely deferred: the alternative export channels (share sheet, clipboard, GitHub
-issue) and an AVFoundation embedded-artwork path for local files.
+Still genuinely deferred: artwork for pure-streamed 26.5 tracks that expose nothing via
+scripting (`count == 0` forever) — would need a non-scripting source (MediaRemote now-playing,
+or MusicKit); the alternative export channels (share sheet, clipboard, GitHub issue); and an
+AVFoundation embedded-artwork path for local files.

--- a/scripts/verify-logging.swift
+++ b/scripts/verify-logging.swift
@@ -19,7 +19,15 @@ func expect(_ condition: Bool, _ message: String) {
 @main
 struct VerifyLogging {
     static func main() {
-        // Assertions are added by later tasks.
+        // LogLine
+        let fixedDate = Date(timeIntervalSince1970: 1_750_000_000) // 2025-06-15T13:46:40Z
+        let ts = LogLine.timestamp(fixedDate)
+        expect(ts.hasSuffix("Z"), "timestamp must end in Z (UTC), got \(ts)")
+        expect(ts.contains("."), "timestamp must include fractional seconds, got \(ts)")
+        let line = LogLine.format(date: fixedDate, category: "artwork", level: "DEBUG", message: "hello")
+        expect(line.contains("[artwork]"), "line must contain bracketed category, got \(line)")
+        expect(line.contains("DEBUG"), "line must contain level, got \(line)")
+        expect(line.hasSuffix("hello"), "line must end with message, got \(line)")
         print("verify-logging: all checks passed")
     }
 }

--- a/scripts/verify-logging.swift
+++ b/scripts/verify-logging.swift
@@ -67,6 +67,19 @@ struct VerifyLogging {
         expect(diag.description.contains("source=streamed"), "description must include derived source")
         expect(diag.description.contains("cloudStatus=subscription"), "description must include cloud status")
 
+        // DiagnosticsReport header (pure)
+        let report = DiagnosticsReport(
+            appVersion: "1.2.1", osVersion: "Version 26.5", connectedApp: "Apple Music",
+            isRunning: true, permissionStatus: "granted", debugLoggingEnabled: true,
+            currentTrackSource: "source=streamed cloudStatus=subscription",
+            exportedAt: Date(timeIntervalSince1970: 1_750_000_000))
+        let header = report.header()
+        expect(header.contains("1.2.1"), "header must include app version")
+        expect(header.contains("Version 26.5"), "header must include macOS version")
+        expect(header.contains("Apple Music"), "header must include connected app")
+        expect(header.contains("granted"), "header must include permission status")
+        expect(header.contains("source=streamed"), "header must include current track source")
+
         print("verify-logging: all checks passed")
     }
 }

--- a/scripts/verify-logging.swift
+++ b/scripts/verify-logging.swift
@@ -28,6 +28,29 @@ struct VerifyLogging {
         expect(line.contains("[artwork]"), "line must contain bracketed category, got \(line)")
         expect(line.contains("DEBUG"), "line must contain level, got \(line)")
         expect(line.hasSuffix("hello"), "line must end with message, got \(line)")
+        // LogFileWriter.shouldRotate (pure)
+        expect(LogFileWriter.shouldRotate(currentBytes: 0, incomingBytes: 100, maxBytes: 50) == false,
+               "empty file must never rotate")
+        expect(LogFileWriter.shouldRotate(currentBytes: 40, incomingBytes: 5, maxBytes: 50) == false,
+               "under cap must not rotate")
+        expect(LogFileWriter.shouldRotate(currentBytes: 48, incomingBytes: 5, maxBytes: 50) == true,
+               "over cap must rotate")
+
+        // LogFileWriter round-trip in a temp dir
+        let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("jukebox-verify-\(UUID().uuidString)", isDirectory: true)
+        let logURL = tmpDir.appendingPathComponent("Jukebox.log")
+        let writer = LogFileWriter(fileURL: logURL, maxBytes: 64)
+        writer.append(String(repeating: "a", count: 50))   // ~51 bytes, under cap
+        expect(FileManager.default.fileExists(atPath: logURL.path), "log file must be created")
+        writer.append(String(repeating: "b", count: 50))   // pushes over cap -> rotates first
+        let rolledURL = logURL.appendingPathExtension("1")
+        expect(FileManager.default.fileExists(atPath: rolledURL.path), "rolled file Jukebox.log.1 must exist")
+        let current = (try? String(contentsOf: logURL, encoding: .utf8)) ?? ""
+        expect(current.contains("b") && !current.contains("a"),
+               "after rotation, current file holds only the newest line")
+        try? FileManager.default.removeItem(at: tmpDir)
+
         print("verify-logging: all checks passed")
     }
 }

--- a/scripts/verify-logging.swift
+++ b/scripts/verify-logging.swift
@@ -51,6 +51,22 @@ struct VerifyLogging {
                "after rotation, current file holds only the newest line")
         try? FileManager.default.removeItem(at: tmpDir)
 
+        // TrackSourceType classifier (pure)
+        expect(TrackDiagnostics.classify(hasAddress: true, hasFileLocation: false, cloudStatus: "unknown") == .internetRadioStream,
+               "an address means internet radio stream")
+        expect(TrackDiagnostics.classify(hasAddress: false, hasFileLocation: true, cloudStatus: "unknown") == .localFile,
+               "a file location means local file")
+        expect(TrackDiagnostics.classify(hasAddress: false, hasFileLocation: false, cloudStatus: "subscription") == .streamed,
+               "subscription with no location means streamed")
+        expect(TrackDiagnostics.classify(hasAddress: false, hasFileLocation: false, cloudStatus: "purchased") == .streamed,
+               "purchased cloud track with no location means streamed")
+        expect(TrackDiagnostics.classify(hasAddress: false, hasFileLocation: false, cloudStatus: "unknown") == .unknown,
+               "no signals means unknown")
+        let diag = TrackDiagnostics(sourceType: .streamed, cloudStatus: "subscription", kind: "Apple Music AAC audio file",
+                                    mediaKind: "song", hasLocation: false, sizeBytes: 0, address: nil)
+        expect(diag.description.contains("source=streamed"), "description must include derived source")
+        expect(diag.description.contains("cloudStatus=subscription"), "description must include cloud status")
+
         print("verify-logging: all checks passed")
     }
 }

--- a/scripts/verify-logging.swift
+++ b/scripts/verify-logging.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+// Standalone verification of the AppKit-free logging core. Compiled together
+// with the real source files (no copies). Run via:
+//
+//   swiftc Jukebox/Utilities/LogLine.swift \
+//          Jukebox/Utilities/LogFileWriter.swift \
+//          Jukebox/Utilities/TrackSourceType.swift \
+//          Jukebox/Utilities/DiagnosticsReport.swift \
+//          scripts/verify-logging.swift -o /tmp/verify-logging && /tmp/verify-logging
+
+func expect(_ condition: Bool, _ message: String) {
+    if !condition {
+        FileHandle.standardError.write(Data("FAIL: \(message)\n".utf8))
+        exit(1)
+    }
+}
+
+@main
+struct VerifyLogging {
+    static func main() {
+        // Assertions are added by later tasks.
+        print("verify-logging: all checks passed")
+    }
+}

--- a/scripts/verify-logging.swift
+++ b/scripts/verify-logging.swift
@@ -52,16 +52,20 @@ struct VerifyLogging {
         try? FileManager.default.removeItem(at: tmpDir)
 
         // TrackSourceType classifier (pure)
-        expect(TrackDiagnostics.classify(hasAddress: true, hasFileLocation: false, cloudStatus: "unknown") == .internetRadioStream,
+        expect(TrackDiagnostics.classify(hasAddress: true, hasFileLocation: false, cloudStatus: "unknown", sizeBytes: 0) == .internetRadioStream,
                "an address means internet radio stream")
-        expect(TrackDiagnostics.classify(hasAddress: false, hasFileLocation: true, cloudStatus: "unknown") == .localFile,
-               "a file location means local file")
-        expect(TrackDiagnostics.classify(hasAddress: false, hasFileLocation: false, cloudStatus: "subscription") == .streamed,
-               "subscription with no location means streamed")
-        expect(TrackDiagnostics.classify(hasAddress: false, hasFileLocation: false, cloudStatus: "purchased") == .streamed,
-               "purchased cloud track with no location means streamed")
-        expect(TrackDiagnostics.classify(hasAddress: false, hasFileLocation: false, cloudStatus: "unknown") == .unknown,
-               "no signals means unknown")
+        expect(TrackDiagnostics.classify(hasAddress: false, hasFileLocation: true, cloudStatus: "unknown", sizeBytes: 5_000_000) == .localFile,
+               "a file:// location WITH a non-zero size means local file")
+        expect(TrackDiagnostics.classify(hasAddress: false, hasFileLocation: false, cloudStatus: "subscription", sizeBytes: 0) == .streamed,
+               "subscription means streamed")
+        expect(TrackDiagnostics.classify(hasAddress: false, hasFileLocation: true, cloudStatus: "purchased", sizeBytes: 9_000_000) == .streamed,
+               "a known cloud status wins even with a local file present")
+        // Regression (macOS 26.5): a streamed Apple Music track reports a location but size 0 —
+        // it must NOT be classified localFile.
+        expect(TrackDiagnostics.classify(hasAddress: false, hasFileLocation: true, cloudStatus: "unrecognised", sizeBytes: 0) == .streamed,
+               "location present but zero size (no local bytes) means streamed, not localFile")
+        expect(TrackDiagnostics.classify(hasAddress: false, hasFileLocation: false, cloudStatus: "unknown", sizeBytes: 1234) == .unknown,
+               "no address, no cloud status, no file location, non-zero size means unknown")
         let diag = TrackDiagnostics(sourceType: .streamed, cloudStatus: "subscription", kind: "Apple Music AAC audio file",
                                     mediaKind: "song", hasLocation: false, sizeBytes: 0, address: nil)
         expect(diag.description.contains("source=streamed"), "description must include derived source")


### PR DESCRIPTION
## Summary
Started as an opt-in **debug logging** facility; on-device verification across macOS 26.5 and 15 then turned it into the fix for the empty-album-art bug, the macOS-26.5 ScriptingBridge crashes it exposed, and a couple of cross-OS UI fixes.

**Debug logging**
- A single `Log` facade → `os.Logger` (always) + a size-capped, opt-in log file (`~/Library/Application Support/Jukebox/Logs/Jukebox.log`, ~5 MB single rollover), gated by a new **Preferences ▸ Debugging** toggle. **Export Logs…** bundles a diagnostics header with the log and reveals it in Finder.

**macOS 26.5 ScriptingBridge fixes (surfaced by the logging)**
- `location` `EXC_BREAKPOINT`: typed `MusicFileTrack.location` as `URL?` (a non-optional value type trapped on a missing value).
- `data` `unrecognized selector`: `MusicArtwork.data` is an `NSAppleEventDescriptor`, not an `NSImage` — stopped calling NSImage methods on it.
- `SBElementArray.first` returns nil even when `count > 0` → use the `[0]` subscript.
- Track source-type is size-based (streamed tracks report a location + `size == 0` on 26.5), not location-presence.

**Album art (cross-OS, both fixed)**
- Resolver tries `data`-as-`NSImage` (macOS ≤15) → `rawData` → `rawData` proxy via `SBObject.get()` → `data` descriptor payload → `NSImage(data:)`. Correct per-track covers on macOS 15 and 26.5.
- Polls for async-loaded artwork (`artworks().count == 0` at the track change) instead of bailing immediately.

**UI fixes**
- Preferences window height raised so the Debugging pane isn't clipped.
- Popover uses `preferredContentSize` so macOS 26 matches the macOS 15 layout (`contentSize`/`sizingOptions` are ignored on 26).

## Test Plan
- [x] Standalone `scripts/verify-logging.swift` passes (formatting, rollover, classifier + regression, header).
- [x] `xcodebuild -scheme Jukebox build` succeeds.
- [x] On-device matrix verified — macOS 15.7.4 + 26.5.1, Apple Music + Spotify: no crashes, album art renders with correct covers, Preferences window not clipped, popover layout matches across OSes.

**Known optional follow-up (out of scope):** pure-streamed Apple Music tracks that report `artworks().count == 0` forever on 26.5 expose no artwork via scripting — would need MediaRemote/MusicKit.